### PR TITLE
feat: add CLI and framework consistency improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,314 +1,46 @@
 ---
 # 规范版本: agentic-ai-foundation/v1
 # 适用范围：整个仓库
-# 最后更新：2026-03-08
+# 最后更新：2026-05-31
 ---
 
 # AGENTS.md
 
-## 项目概览
-
-这是一个基于 Koa 的 QQ 音乐 API 服务项目，当前代码库已完成从 JavaScript 到 TypeScript 的迁移。
-
-- 运行时：Node.js 20+
-- 开发语言：TypeScript
-- Web 框架：Koa 2
-- 路由系统：@koa/router
-- 文档系统：VitePress
-- 测试框架：Vitest
-
-## 启动与构建
-
-### 安装依赖
-
-```bash
-npm install
-```
-
-### 开发模式
-
-```bash
-npm run dev
-```
-
-默认开发启动入口为 `src/app.ts`，默认端口为 `3200`。
-
-### 生产构建
-
-```bash
-npm run build
-```
-
-### 生产运行
-
-```bash
-npm run start
-```
-
-## Toolchain
-
-| 意图     | 命令                                 | 配置权威                        |
-| -------- | ------------------------------------ | ------------------------------- |
-| 开发     | `npm run dev`                        | `package.json`                  |
-| 构建     | `npm run build`                      | `tsconfig.json`                 |
-| 测试     | `npm run test`                       | `vitest.config.ts`              |
-| 代码检查 | `npm run lint`                       | `.oxlintrc.json`                |
-| 格式化   | `npm run format`                     | `.prettierrc`                   |
-| 文档开发 | `npm run docs:dev`                   | `docs/.vitepress/config.mjs`    |
-| 发版     | `git push origin main --follow-tags` | `.github/workflows/package.yml` |
-
-**提交前必须执行**：
-
-```bash
-npm run build && npm run test && npm run docs:build
-```
-
-## 目录结构
-
-```text
-src/app.ts             应用启动入口
-src/index.ts           包导出入口
-src/services/        API 请求封装层
-src/controllers/     HTTP 控制器
-src/routes/          路由注册与 API 元数据
-src/middlewares/     Koa 中间件
-src/util/            通用工具函数
-src/config/          运行时配置
-src/types/           全局类型与公共类型定义
-docs/                  VitePress 文档站点
-tests/                 单元测试与集成测试
-public/                静态资源
-scripts/               辅助脚本
-```
-
-## 分层说明
-
-### src/services/
-
-负责直接请求 QQ 音乐相关接口，通常只处理：
-
-- 请求参数拼装
-- 调用上游接口
-- 基础数据格式转换
-- 返回统一响应结构
-
-### src/controllers/
-
-负责 HTTP 层控制器逻辑，通常只处理：
-
-- 读取 `ctx.query` 或 `ctx.request.body`
-- 参数校验
-- 调用 `src/services/` 中对应能力
-- 设置 `ctx.body` 与 `ctx.status`
-
-### src/routes/router.ts
-
-负责统一注册所有路由。
-
-### src/util/
-
-放置跨模块复用的通用逻辑，例如响应包装、颜色输出等。
-
-## 编码约定
-
-1. 新增功能时，优先保持现有目录分层，不要把路由逻辑和接口请求逻辑混写。
-2. 新增接口时，通常需要同时补充：
-   - `src/services/apis/...` 中的接口实现
-   - `src/controllers/...` 中的控制器
-   - `src/controllers/index.ts` 或相关导出
-   - `src/routes/router.ts` 中的路由注册
-   - 必要时补充文档与测试
-3. 统一使用 TypeScript，避免继续引入新的 `.js` 业务文件。
-4. 尽量复用已有类型定义，公共类型优先放到 `src/types/`。
-5. 保持返回结构一致，优先复用已有响应工具。
-6. 修改 Cookie 相关逻辑时，参考 `tests/integration/login.test.ts` 验证扫码登录兼容性
-
-## 行为边界
-
-1. 仅在当前仓库内执行分析、修改与命令操作，不推断或操作仓库外文件。
-2. 修改实现时，必须遵守既有分层边界：`src/services/` 不写 HTTP 控制器逻辑，`src/controllers/` 不直接承载上游请求细节，`src/routes/router.ts` 只负责路由注册。
-3. 涉及扫码登录、Cookie、用户信息或其他敏感配置时，只能做兼容性修复与明确需求内的改动，不得擅自重构认证流程、扩展凭据用途或删除保护逻辑。
-4. 未经需求明确，不新增外部服务依赖、不修改默认端口、不调整公开接口返回结构、不改变现有路由语义。
-5. 文档、测试、类型与实现应保持同步；如果本次任务只允许文档修改，则不得顺带改动业务代码。
-6. 对不确定的业务规则，优先保守处理并在提交说明中写明假设，避免以猜测替代已验证行为。
-7. 禁止引入与任务无关的大规模重构、批量格式化或目录迁移，避免扩大变更面。
-8. 删除文件、调整公共配置、修改构建脚本前，必须确认该变更是任务目标的一部分，且不会破坏现有构建、测试与文档流程。
-
-## 测试与验证
-
-提交前建议至少执行：
-
-```bash
-npm run build
-npm run test
-```
-
-如果修改了文档，再执行：
-
-```bash
-npm run docs:build
-```
-
-如果修改了格式或风格敏感文件，再执行：
-
-```bash
-npm run lint
-npm run format
-```
-
-## 关键注意事项
-
-1. 项目默认端口为 `3200`。
-2. 生产启动依赖 `dist/` 目录，因此发布前必须先执行构建。
-3. 当前仓库包含扫码登录相关接口实现，不要在未理解流程前随意调整登录状态字段。
-4. 文档内容位于 `docs/`，接口能力变更时要同步更新文档。
-5. 现有测试以 Vitest 为主，新增行为建议补充对应测试。
-
-## 建议的开发流程
-
-1. 阅读相关模块现有实现。
-2. 在 `src/services/` 增加或调整接口能力。
-3. 在 `src/controllers/` 接入 HTTP 控制器。
-4. 在路由层完成注册。
-5. 补充类型、测试与文档。
-6. 执行构建和测试，确认无误后再提交。
-
-## 发版流程
-
-### 发布策略说明
-
-**重要**：本项目采用 **文档与包分离发布** 策略。
-
-| 内容                  | 触发条件          | 发布方式       | 说明                                   |
-| --------------------- | ----------------- | -------------- | -------------------------------------- |
-| **GitHub Pages 文档** | 推送 main 分支    | 自动部署       | 永远与 main 同步，可能领先 npm         |
-| **npm 包**            | 手动触发 workflow | GitHub Actions | 正式版本，发布到 NPM + GitHub Packages |
-
-**核心规则：**
-
-```
-文档部署：push main → 自动部署（无需手动操作）
-包发布：  手动触发 workflow → 发布到 NPM + GitHub Packages
-```
-
-### 发版方式说明
-
-本项目采用 **GitHub Actions 自动化发版** 作为标准流程。本地只负责触发，所有发布步骤由 GitHub 自动完成。
-
-### 版本与文档策略
-
-**文档部署策略：**
-
-- ✅ **文档永远与 main 分支同步** - 每次推送到 main 自动部署最新文档
-- ✅ **文档可以领先 npm 版本** - 不需要等待发布，文档即时更新
-- ✅ **GitHub Pages** - 始终反映最新代码状态（可能包含未发布的功能）
-- ⚠️ **文档部署独立于包发布** - 推送到 main 就会部署文档，不需要推送标签
-
-**版本发布策略：**
-
-- 📦 **npm 包** - 手动触发 workflow 发布（正式版本）
-- 📦 **CHANGELOG** - 基于 Git 提交历史生成
-- 📦 **package.json 版本** - 自动维护（每次 push 到 main 自动 bump patch 版本）
-- ⚠️ **包发布需要手动触发** - 在 GitHub Actions 手动触发 publish workflow（可选输入标签）
-
-**总结：**
-
-```
-GitHub Pages 文档   = main 分支最新状态（可能领先 npm）
-package.json 版本   = 自动 bump（每次 push 到 main）
-npm 包版本         = package.json 的版本（或手动指定的标签版本）
-
-文档部署：自动（push main 触发）
-版本管理：自动（push main 时自动 bump patch 版本）
-包发布：    手动触发（发布到 NPM + GitHub Packages）
-```
-
-**注意事项：**
-
-1. **不要依赖本地发布** - 本地 `npm publish` 仅用于测试，不是标准发布方式
-2. **文档总是最新** - GitHub Pages 可能包含未发布的功能文档
-3. **package.json 版本自动维护** - 每次 push 到 main 会自动 bump patch 版本（用于开发版本追踪）
-4. **正式发布默认使用 package.json 版本** - npm 包默认使用 package.json 的版本号
-5. **可选指定标签** - 可以在触发 workflow 时输入特定标签名发布历史版本
-6. **发布到两个仓库** - 同时发布到 NPM 和 GitHub Packages（镜像/备份）
-7. **手动触发原因** - 发布前可以在 GitHub Actions 页面确认所有测试通过
-
-### 标准发版步骤
-
-1. **确保所有测试通过**
-
-   ```bash
-   npm run test
-   ```
-
-2. **本地构建验证**
-
-   ```bash
-   npm run build
-   npm run docs:build
-   ```
-
-3. **手动触发发布 workflow**
-   - 访问：https://github.com/sansenjian/qq-music-api/actions/workflows/package.yml
-   - 点击 "Run workflow"
-   - **不需要输入任何内容**（留空即可，会自动使用 `package.json` 的版本号）
-   - 点击 "Run workflow" 按钮
-
-   GitHub Actions 会自动：
-   - ✅ 检出当前 main 分支的代码
-   - ✅ 安装依赖
-   - ✅ 运行测试（npm test）
-   - ✅ 运行代码检查（npm run lint）
-   - ✅ 构建 TypeScript 和文档
-   - ✅ 生成 CHANGELOG
-   - ✅ 发布到 npm
-   - ✅ 发布到 GitHub Packages
-
-   **可选**：如果需要发布特定 Git 标签的版本，可以在 "Tag to release" 输入框中输入标签名（如 `v1.0.0`）。
-
-4. **验证发布结果**
-   - 检查 GitHub Actions 状态：https://github.com/sansenjian/qq-music-api/actions
-   - 查看 npm 包：https://www.npmjs.com/package/@sansenjian/qq-music-api
-   - 查看 GitHub Packages：https://github.com/sansenjian/qq-music-api/pkgs/npm/qq-music-api
-
-### 快捷发版命令
-
-**注意**：推荐使用完整的发版流程（如上），让 GitHub Actions 自动完成所有步骤。
-
-如果确实需要手动发布（不推荐），可以：
-
-```bash
-# 1. 更新版本号（会自动生成 CHANGELOG）
-npm version patch
-
-# 2. 手动构建和发布（仅本地测试）
-npm run build
-npm run docs:build
-npm publish
-```
-
-但这会跳过 GitHub Actions 的自动化流程，不建议作为常规发版方式。
-
-### 版本规范
-
-- **Patch (补丁版本)**: `1.0.0` → `1.0.1` - Bug 修复，无新功能
-- **Minor (小版本)**: `1.0.0` → `1.1.0` - 新增功能，向后兼容
-- **Major (主版本)**: `1.0.0` → `2.0.0` - 破坏性变更
-
-### 发版前检查清单
-
-- [ ] 所有测试通过 (`npm run test`)
-- [ ] 本地构建成功 (`npm run build`)
-- [ ] 文档构建成功 (`npm run docs:build`)
-- [ ] CHANGELOG.md 已生成并审查
-- [ ] package.json 版本号正确
-- [ ] GitHub Actions 发布成功
-- [ ] npm 包已发布
-- [ ] GitHub Packages 已发布
-
-### 注意事项
-
-1. 发版前必须确保 `dist/` 目录是最新的（先执行 `npm run build`）
-2. CHANGELOG 基于 Git Commit Message 自动生成，请保持规范的提交信息
-3. 发布到 npm 前请确认版本号符合语义化版本规范
-4. 如有破坏性变更，请在 CHANGELOG 中明确说明迁移指南
+QQ Music API 是一个基于 Koa 2 和 TypeScript 的 QQ 音乐 API 服务，包含 HTTP 服务、包导出入口和 VitePress 文档站点。
+
+## Quick Reference
+
+- Runtime: Node.js `^20.17.0 || >=22.9.0`
+- Package manager: `npm@11.14.1`
+- App entry: `src/app.ts`
+- Package entry: `src/index.ts`
+- Default port: `3200`
+- Production start requires `dist/`
+- Scope: only operate inside this repository unless the user explicitly asks otherwise.
+
+## Commands
+
+| Intent | Command | Source of truth |
+| --- | --- | --- |
+| Install | `npm install` | `package.json` |
+| Dev server | `npm run dev` | `src/app.ts` |
+| Build | `npm run build` | `vite.config.ts`, `tsconfig.json` |
+| Production start | `npm run start` | `dist/app.js` |
+| Test | `npm run test` | `vitest.config.ts` |
+| Lint | `npm run lint` | `.oxlintrc.json` |
+| Format TS | `npm run format` | `.prettierrc` |
+| Docs dev | `npm run docs:dev` | `docs/.vitepress/config.mjs` |
+| Docs build | `npm run docs:build` | `docs/.vitepress/config.mjs` |
+| Package release | manually trigger `.github/workflows/package.yml` | GitHub Actions |
+
+## Required Validation
+
+For code changes, run `npm run build && npm run test` before handoff. If docs changed, also run `npm run docs:build`. If formatting or lint-sensitive files changed, run `npm run lint` or `npm run format` as appropriate.
+
+## Detailed Instructions
+
+- [Architecture and layering](docs/agent-instructions/architecture.md)
+- [Development workflow](docs/agent-instructions/development.md)
+- [Testing and validation](docs/agent-instructions/testing.md)
+- [Safety boundaries](docs/agent-instructions/safety.md)
+- [Release workflow](docs/agent-instructions/release.md)

--- a/docs/agent-instructions/architecture.md
+++ b/docs/agent-instructions/architecture.md
@@ -1,0 +1,65 @@
+# Architecture and Layering
+
+## Overview
+
+Use this file when adding or changing API behavior, moving code between layers, or checking whether a change belongs in a service, controller, route, utility, or type module.
+
+## Project Shape
+
+| Path | Role |
+| --- | --- |
+| `src/app.ts` | Application startup entry |
+| `src/index.ts` | Package export entry |
+| `src/koaApp.ts` | Koa app composition |
+| `src/services/` | QQ Music upstream request and API capability layer |
+| `src/controllers/` | HTTP controller layer |
+| `src/routes/` | Route registration and API metadata |
+| `src/middlewares/` | Koa middleware |
+| `src/util/` | Shared utility helpers |
+| `src/config/` | Runtime configuration |
+| `src/types/` | Shared and global TypeScript types |
+| `docs/` | VitePress documentation |
+| `tests/` | Unit and integration tests |
+| `public/` | Static assets |
+| `scripts/` | Maintenance and build scripts |
+
+## Layer Rules
+
+### `src/services/`
+
+- Build upstream QQ Music request parameters.
+- Call upstream APIs.
+- Perform basic response conversion.
+- Return the project's unified response structures.
+- Do not read or mutate Koa `ctx`, set HTTP status, or own route-level validation.
+
+### `src/controllers/`
+
+- Read `ctx.query` or `ctx.request.body`.
+- Validate request parameters for the HTTP surface.
+- Call the corresponding service function.
+- Set `ctx.body` and `ctx.status`.
+- Do not inline upstream request details that belong in `src/services/`.
+
+### `src/routes/router.ts`
+
+- Register routes and connect them to controllers.
+- Keep route semantics stable unless the task explicitly requires an API change.
+- Keep API metadata synchronized when route capabilities change.
+
+### `src/util/`
+
+- Put cross-module helpers here, such as response wrappers, cookie helpers, request helpers, logging, and color output.
+- Prefer existing helpers before adding a new utility.
+
+## Adding an API
+
+When adding an endpoint, normally update these areas together:
+
+- `src/services/apis/...` for the upstream capability.
+- `src/controllers/...` for HTTP controller logic.
+- `src/controllers/index.ts` or the relevant export barrel.
+- `src/routes/router.ts` for route registration.
+- `src/routes/api-metadata.ts` if public API metadata changes.
+- `src/types/` when shared public or cross-module types are needed.
+- `docs/api/...` and tests when behavior is user-visible.

--- a/docs/agent-instructions/development.md
+++ b/docs/agent-instructions/development.md
@@ -1,0 +1,32 @@
+# Development Workflow
+
+## Overview
+
+Use this file for day-to-day implementation choices, TypeScript conventions, and keeping code, tests, and docs synchronized.
+
+## Working Rules
+
+- Preserve the existing Koa, TypeScript, Vite, VitePress, and Vitest stack.
+- Avoid adding new JavaScript business files; keep application logic in TypeScript.
+- JavaScript maintenance scripts are acceptable when matching existing `scripts/*.js` patterns.
+- Keep changes scoped to the requested behavior and nearby ownership boundaries.
+- Reuse existing types before adding new public types. Put shared types in `src/types/`.
+- Reuse existing response helpers so public response structures stay consistent.
+- Do not introduce a new dependency unless it is part of the task and the existing stack cannot reasonably solve the problem.
+- Do not change the default port `3200` unless the user explicitly asks for it.
+- Keep implementation, tests, and documentation synchronized for user-visible behavior changes.
+
+## Recommended Flow
+
+1. Read the relevant service, controller, route, type, and test modules.
+2. Implement upstream API behavior in `src/services/`.
+3. Wire HTTP behavior in `src/controllers/`.
+4. Register or adjust routes in `src/routes/router.ts`.
+5. Update shared types, tests, and docs when the public surface changes.
+6. Run the smallest useful validation first, then the required handoff checks.
+
+## Documentation Changes
+
+- API behavior changes should update the corresponding page under `docs/api/`.
+- Usage or setup changes should update `docs/guide/` or other existing documentation pages.
+- Keep VitePress configuration changes in `docs/.vitepress/config.mjs`.

--- a/docs/agent-instructions/release.md
+++ b/docs/agent-instructions/release.md
@@ -1,0 +1,46 @@
+# Release Workflow
+
+## Overview
+
+Use this file for versioning, documentation deployment, and npm/GitHub Packages publication tasks.
+
+## Strategy
+
+This project separates documentation deployment from package publication.
+
+| Artifact | Trigger | Workflow | Result |
+| --- | --- | --- | --- |
+| GitHub Pages docs | Push to `main` or manual dispatch | `.github/workflows/deploy-docs.yml` | Deploys latest `main` docs |
+| Version bump | Push to `main` or manual dispatch | `.github/workflows/version.yml` | Updates `package.json`, `CHANGELOG.md`, and `docs/public/version.json` |
+| npm package | Manual dispatch | `.github/workflows/package.yml` | Publishes to npm and GitHub Packages |
+
+## Package Publication
+
+- Standard package release is the manual GitHub Actions workflow `.github/workflows/package.yml`.
+- Leave the `Tag to release` input empty to publish the current `package.json` version.
+- Provide a tag only when intentionally publishing that historical tag.
+- Do not treat `git push origin main --follow-tags` as the package release trigger; package publication is manual.
+- Do not use local `npm publish` as the normal release path unless the user explicitly asks for a manual/local publish test.
+
+## Pre-Release Validation
+
+Before triggering package publication, verify:
+
+- `npm run test`
+- `npm run lint`
+- `npm run build`
+- `npm run docs:build`
+- `package.json` version is the intended version.
+- `CHANGELOG.md` has been generated and reviewed when relevant.
+
+## Workflow Behavior
+
+The package workflow checks out the selected ref, installs dependencies, runs tests, runs lint, builds TypeScript, builds documentation, generates the changelog, then publishes to npm and GitHub Packages.
+
+## Verification
+
+After publication, check:
+
+- GitHub Actions run status under `actions/workflows/package.yml`.
+- npm package page for `@sansenjian/qq-music-api`.
+- GitHub Packages entry for this repository.

--- a/docs/agent-instructions/safety.md
+++ b/docs/agent-instructions/safety.md
@@ -1,0 +1,29 @@
+# Safety Boundaries
+
+## Overview
+
+Use this file before making changes that could affect public API behavior, authentication, configuration, dependencies, routing, or repository structure.
+
+## Repository Scope
+
+- Analyze, modify, and run commands only inside this repository unless the user explicitly requests work elsewhere.
+- Do not infer or mutate files outside the repository as part of this project's maintenance work.
+
+## Public API Stability
+
+- Do not change existing route semantics without an explicit requirement.
+- Do not change public response structures unless the task specifically asks for it.
+- Do not change default runtime configuration such as port `3200` without a clear requirement.
+- Keep API metadata, docs, and tests aligned when public behavior changes.
+
+## Authentication and User Data
+
+- For QR login, Cookie, user information, and credential-related code, make only compatibility fixes or explicitly requested changes.
+- Do not redesign the authentication flow without first confirming that it is part of the task.
+- Do not expand credential usage, weaken protective logic, or remove validation as an incidental cleanup.
+
+## Change Control
+
+- Do not introduce unrelated large refactors, bulk formatting, or directory migrations.
+- Do not delete files, adjust public configuration, or alter build scripts unless that change is necessary for the task.
+- If a business rule is uncertain, handle it conservatively and call out the assumption in the handoff.

--- a/docs/agent-instructions/testing.md
+++ b/docs/agent-instructions/testing.md
@@ -1,0 +1,34 @@
+# Testing and Validation
+
+## Overview
+
+Use this file when choosing which checks to run or when adding tests for changed behavior.
+
+## Required Checks
+
+- Code changes: run `npm run build && npm run test` before handoff.
+- Documentation changes: run `npm run docs:build`.
+- Lint-sensitive changes: run `npm run lint`.
+- Formatting-only or formatting-sensitive changes: run `npm run format` when appropriate.
+
+## Focused Checks
+
+- Unit tests: `npm run test:unit`.
+- All Vitest tests: `npm run test`.
+- Coverage: `npm run test:coverage`.
+- Verbose test output: `npm run test:verbose`.
+- Flagged test runner: `npm run test:flags` or `npm run test:flags:unit`.
+
+## Test Placement
+
+- Controller tests belong under `tests/unit/controllers/`.
+- Service API tests belong under `tests/unit/services/apis/` or the relevant service test folder.
+- Middleware tests belong under `tests/integration/middleware/` when behavior crosses Koa middleware boundaries.
+- API integration tests belong under `tests/integration/api/` when route behavior is being exercised.
+- Utility tests belong under `tests/unit/util/`.
+
+## Cookie and Login Changes
+
+- Treat Cookie, QR login, user identity, and credential handling as sensitive behavior.
+- Inspect existing cookie and login-related tests before changing behavior, especially `tests/unit/util/cookie*.test.ts`, `tests/unit/util/cookieResolver.test.ts`, and relevant integration API tests.
+- Add focused coverage when compatibility could change.

--- a/docs/guide/mcp-cli-extension.md
+++ b/docs/guide/mcp-cli-extension.md
@@ -13,6 +13,28 @@ title: MCP 与 CLI 拓展思考
 
 如果继续扩展，应避免把 HTTP 服务、命令行工具和 MCP Server 混在一个入口里。三者可以共享底层模块，但运行边界要清晰。
 
+## 当前 CLI 状态
+
+当前 `qq-music-api` 已经提供最小 CLI：
+
+```bash
+qq-music-api
+qq-music-api serve
+qq-music-api config path
+qq-music-api config doctor
+qq-music-api doctor
+qq-music-api auth status
+qq-music-api auth clear
+```
+
+说明：
+
+- `qq-music-api` 无参数时仍保持旧行为，默认启动 HTTP 服务。
+- `serve` 支持 `--port <port>` 和 `--json`。
+- `config path`、`config doctor`、`doctor`、`auth status`、`auth clear` 支持 `--json`。
+- `auth status` 不输出完整 Cookie，只输出登录态是否存在和 Cookie key 列表。
+- MCP Server 尚未实现，仍属于后续扩展方向。
+
 ## 目标
 
 后续拓展可以围绕三个方向推进：

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"koa": "^2.16.4"
 			},
 			"bin": {
-				"qq-music-api": "dist/app.js"
+				"qq-music-api": "dist/cli.js"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "^20.5.3",

--- a/package.json
+++ b/package.json
@@ -23,13 +23,17 @@
 		}
 	},
 	"bin": {
-		"qq-music-api": "dist/app.js"
+		"qq-music-api": "dist/cli.js"
 	},
 	"files": [
+		"dist",
 		"dist/app.js",
 		"dist/app.cjs",
 		"dist/app.d.cts",
 		"dist/app.d.mts",
+		"dist/cli.js",
+		"dist/cli.cjs",
+		"dist/cli.d.ts",
 		"dist/index.js",
 		"dist/index.cjs",
 		"dist/index.d.cts",
@@ -81,7 +85,7 @@
 		"release": "npm version patch",
 		"lint": "oxlint",
 		"lint:fix": "oxlint --fix",
-		"format": "prettier --write --tab-width=2 src/**/*.ts",
+		"format": "prettier --write --tab-width=2 \"src/**/*.ts\" \"tests/**/*.ts\" \"scripts/**/*.{js,ts,cjs,mjs}\" \"plugins/**/*.ts\" \"*.config.{js,ts,mjs}\" \"docs/.vitepress/config.mjs\" \"package.json\" \".oxlintrc.json\"",
 		"build:local-images": "node ./scripts/build-images.js local",
 		"build:remote-images": "node ./scripts/build-images.js remote",
 		"build:images": "npm run build:local-images && npm run build:remote-images",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,14 +1,8 @@
-import { styleText } from 'node:util';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import colors from './util/colors';
-import serviceConfig from './config/service-config';
-import pkg from '../package.json';
 import app from './koaApp';
-
-const parsedPort = Number.parseInt(process.env.PORT ?? '', 10);
-const PORT: number = Number.isFinite(parsedPort) ? parsedPort : 3200;
+import { startServer } from './server';
 
 const resolveRealPath = (filePath: string): string => {
 	try {
@@ -22,59 +16,7 @@ const resolveRealPath = (filePath: string): string => {
 const entryFile = process.argv[1] ? resolveRealPath(process.argv[1]) : '';
 const currentFile = resolveRealPath(fileURLToPath(import.meta.url));
 if (entryFile === currentFile) {
-	console.log(styleText('green', '\n🎵 QQ Music API Service Starting...\n'));
-	console.log(colors.info(`Current Version: ${pkg.version}`));
-	console.log(colors.info(`Fallback Mode: ${serviceConfig.fallbackMode ? 'Enabled' : 'Disabled'}`));
-	console.log(colors.info(`Use Global Cookie: ${serviceConfig.useGlobalCookie ? 'Yes' : 'No'}`));
-
-	if (serviceConfig.fallbackMode) {
-		console.log(styleText('green', '\n✅ 降级模式已启用：支持手动传递 Cookie\n'));
-		console.log('使用方式:');
-		console.log('  1. Query 参数：GET /api/endpoint?cookie=your_cookie');
-		console.log('  2. Header: X-Custom-Cookie: your_cookie');
-		console.log('  3. Header: Cookie: your_cookie\n');
-	}
-
-	if (!serviceConfig.useGlobalCookie) {
-		console.log(styleText('yellow', '\n⚠️  全局 Cookie 未启用：需要登录的接口请手动传递 Cookie\n'));
-	} else {
-		console.log(styleText('green', '\n✅ 全局 Cookie 已启用\n'));
-
-		if (!(global.userInfo.loginUin || global.userInfo.uin)) {
-			console.log(
-				styleText(
-					'yellow',
-					`😔 The configuration ${styleText('red', 'loginUin')} or your ${styleText('red', 'cookie')} in file ${styleText('green', 'config/user-info')} has not configured. \n`,
-				),
-			);
-		}
-
-		if (!global.userInfo.cookie) {
-			console.log(
-				styleText(
-					'yellow',
-					`😔 The configuration ${styleText('red', 'cookie')} in file ${styleText('green', 'config/user-info')} has not configured. \n`,
-				),
-			);
-		}
-	}
-
-	const server = app.listen(PORT, () => {
-		console.log(colors.prompt(`server running @ http://localhost:${PORT}`));
-		console.log(colors.info(`open playground @ http://localhost:${PORT}/index.html`));
-	});
-
-	server.on('error', (error: NodeJS.ErrnoException) => {
-		if (error.code === 'EADDRINUSE') {
-			console.error(colors.error(`Port ${PORT} is already in use.`));
-			console.error(colors.warn('Stop the existing process or set PORT to another value before running again.'));
-			process.exit(1);
-		}
-
-		console.error(colors.error('Failed to start server.'));
-		console.error(error);
-		process.exit(1);
-	});
+	startServer();
 }
 
 export default app;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,329 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getConfigDir, resolveConfigPath } from './config/config-path';
+import { getUserInfo, setUserInfo } from './config/user-info-store';
+import type { UserInfo } from './types';
+import pkg from '../package.json';
+
+interface CliIo {
+	stdout: (message: string) => void;
+	stderr: (message: string) => void;
+}
+
+interface ParsedArgs {
+	args: string[];
+	json: boolean;
+	help: boolean;
+	version: boolean;
+	port?: number;
+}
+
+interface JsonFileStatus {
+	path: string;
+	exists: boolean;
+	status: 'ok' | 'missing' | 'invalid';
+	error?: string;
+}
+
+const defaultIo: CliIo = {
+	stdout: message => console.log(message),
+	stderr: message => console.error(message),
+};
+
+const resolveRealPath = (filePath: string): string => {
+	try {
+		return fs.realpathSync.native(filePath);
+	} catch {
+		return path.resolve(filePath);
+	}
+};
+
+const parsePort = (value: string | undefined): number => {
+	if (value === undefined || value === '') {
+		throw new Error('Missing value for --port');
+	}
+	if (!/^\d+$/.test(value)) {
+		throw new Error(`Invalid port: ${value}`);
+	}
+	const port = Number(value);
+	if (!Number.isInteger(port) || port < 0 || port > 65535) {
+		throw new Error(`Invalid port: ${value}`);
+	}
+	return port;
+};
+
+const parseArgs = (argv: string[]): ParsedArgs => {
+	const args = [...argv];
+	const parsed: ParsedArgs = {
+		args: [],
+		json: false,
+		help: false,
+		version: false,
+	};
+
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		if (arg === '--json') {
+			parsed.json = true;
+			continue;
+		}
+		if (arg === '--help' || arg === '-h') {
+			parsed.help = true;
+			continue;
+		}
+		if (arg === '--version' || arg === '-v') {
+			parsed.version = true;
+			continue;
+		}
+		if (arg === '--port' || arg === '-p') {
+			parsed.port = parsePort(args[index + 1]);
+			index += 1;
+			continue;
+		}
+		if (arg.startsWith('--port=')) {
+			parsed.port = parsePort(arg.slice('--port='.length));
+			continue;
+		}
+		parsed.args.push(arg);
+	}
+
+	return parsed;
+};
+
+const printJson = (io: CliIo, payload: unknown) => {
+	io.stdout(JSON.stringify(payload, null, 2));
+};
+
+const printError = (io: CliIo, json: boolean, code: string, message: string): number => {
+	if (json) {
+		io.stderr(JSON.stringify({ ok: false, error: { code, message } }));
+	} else {
+		io.stderr(`Error: ${message}`);
+	}
+	return 1;
+};
+
+const helpText = () => `QQ Music API CLI
+
+Usage:
+  qq-music-api [serve] [--port <port>] [--json]
+  qq-music-api config path [--json]
+  qq-music-api config doctor [--json]
+  qq-music-api doctor [--json]
+  qq-music-api auth status [--json]
+  qq-music-api auth clear [--json]
+
+Options:
+  --json             Output stable machine-readable JSON for supported commands.
+  --port, -p <port>  Port for the serve command.
+  --version, -v      Print package version.
+  --help, -h         Show this help.
+
+Notes:
+  Running qq-music-api with no command keeps the legacy behavior and starts the HTTP service.
+  Auth commands never print the full Cookie value.
+`;
+
+const getPathPayload = () => {
+	const configDir = getConfigDir();
+	return {
+		ok: true,
+		command: 'config path',
+		configDir,
+		serviceConfigPath: resolveConfigPath('service-config.json'),
+		userInfoPath: resolveConfigPath('user-info.json'),
+	};
+};
+
+const readJsonFileStatus = (filePath: string): JsonFileStatus => {
+	if (!fs.existsSync(filePath)) {
+		return { path: filePath, exists: false, status: 'missing' };
+	}
+
+	try {
+		JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+		return { path: filePath, exists: true, status: 'ok' };
+	} catch (error) {
+		return {
+			path: filePath,
+			exists: true,
+			status: 'invalid',
+			error: error instanceof Error ? error.message : 'Invalid JSON',
+		};
+	}
+};
+
+const getCookieKeys = (cookie: string | undefined): string[] => {
+	if (!cookie) return [];
+	return cookie
+		.split(';')
+		.map(item => item.trim())
+		.filter(Boolean)
+		.map(item => item.slice(0, item.indexOf('=')).trim())
+		.filter(Boolean);
+};
+
+const checkWritable = (configDir: string) => {
+	try {
+		fs.mkdirSync(configDir, { recursive: true });
+		const probePath = path.join(configDir, `.doctor-${process.pid}-${Date.now()}.tmp`);
+		fs.writeFileSync(probePath, 'ok', 'utf-8');
+		fs.rmSync(probePath, { force: true });
+		return { writable: true };
+	} catch (error) {
+		return {
+			writable: false,
+			error: error instanceof Error ? error.message : 'Config directory is not writable',
+		};
+	}
+};
+
+const getDoctorPayload = () => {
+	const configDir = getConfigDir();
+	const writable = checkWritable(configDir);
+	const serviceConfig = readJsonFileStatus(resolveConfigPath('service-config.json'));
+	const userInfo = readJsonFileStatus(resolveConfigPath('user-info.json'));
+	const hasInvalidJson = serviceConfig.status === 'invalid' || userInfo.status === 'invalid';
+
+	return {
+		ok: writable.writable && !hasInvalidJson,
+		command: 'config doctor',
+		configDir,
+		platform: os.platform(),
+		nodeVersion: process.version,
+		writable,
+		serviceConfig,
+		userInfo,
+	};
+};
+
+const getAuthStatusPayload = () => {
+	const userInfo = getUserInfo();
+	const cookieKeys = getCookieKeys(userInfo.cookie);
+
+	return {
+		ok: true,
+		command: 'auth status',
+		authenticated: Boolean(userInfo.cookie && (userInfo.uin || userInfo.loginUin)),
+		uin: userInfo.uin || userInfo.loginUin || '',
+		hasCookie: Boolean(userInfo.cookie),
+		cookieKeys,
+		cookieCount: cookieKeys.length,
+	};
+};
+
+const emptyUserInfo = (): UserInfo => ({
+	loginUin: '',
+	uin: '',
+	cookie: '',
+	cookieList: [],
+	cookieObject: {},
+	refreshData: () => ({}),
+});
+
+const clearAuth = () => {
+	const configDir = getConfigDir();
+	const userInfoPath = resolveConfigPath('user-info.json');
+	fs.mkdirSync(configDir, { recursive: true });
+	fs.writeFileSync(userInfoPath, `${JSON.stringify({ loginUin: '', cookie: '' }, null, 2)}\n`, 'utf-8');
+	setUserInfo(emptyUserInfo());
+
+	return {
+		ok: true,
+		command: 'auth clear',
+		cleared: true,
+		userInfoPath,
+	};
+};
+
+const printHumanPath = (io: CliIo) => {
+	const payload = getPathPayload();
+	io.stdout(`Config directory: ${payload.configDir}`);
+	io.stdout(`Service config:    ${payload.serviceConfigPath}`);
+	io.stdout(`User info:         ${payload.userInfoPath}`);
+};
+
+const printHumanDoctor = (io: CliIo) => {
+	const payload = getDoctorPayload();
+	io.stdout(`Config directory: ${payload.configDir}`);
+	io.stdout(`Writable:         ${payload.writable.writable ? 'yes' : 'no'}`);
+	io.stdout(`service-config:   ${payload.serviceConfig.status}`);
+	io.stdout(`user-info:        ${payload.userInfo.status}`);
+	io.stdout(`Overall:          ${payload.ok ? 'ok' : 'needs attention'}`);
+};
+
+const printHumanAuthStatus = (io: CliIo) => {
+	const payload = getAuthStatusPayload();
+	io.stdout(`Authenticated: ${payload.authenticated ? 'yes' : 'no'}`);
+	io.stdout(`UIN:           ${payload.uin || 'missing'}`);
+	io.stdout(`Cookie:        ${payload.hasCookie ? 'present' : 'missing'}`);
+	io.stdout(`Cookie keys:   ${payload.cookieKeys.length ? payload.cookieKeys.join(', ') : 'none'}`);
+};
+
+export const runCli = async (argv: string[] = process.argv.slice(2), io: CliIo = defaultIo): Promise<number> => {
+	let parsed: ParsedArgs;
+	try {
+		parsed = parseArgs(argv);
+	} catch (error) {
+		return printError(io, argv.includes('--json'), 'INVALID_ARGS', error instanceof Error ? error.message : 'Invalid arguments');
+	}
+
+	const [command = 'serve', subcommand] = parsed.args;
+
+	if (parsed.version) {
+		io.stdout(pkg.version);
+		return 0;
+	}
+
+	if (parsed.help) {
+		io.stdout(helpText());
+		return 0;
+	}
+
+	try {
+		if (command === 'serve') {
+			const { startServer } = await import('./server');
+			startServer({ port: parsed.port, json: parsed.json });
+			return 0;
+		}
+
+		if (command === 'config' && subcommand === 'path') {
+			if (parsed.json) printJson(io, getPathPayload());
+			else printHumanPath(io);
+			return 0;
+		}
+
+		if ((command === 'config' && subcommand === 'doctor') || command === 'doctor') {
+			if (parsed.json) printJson(io, getDoctorPayload());
+			else printHumanDoctor(io);
+			return 0;
+		}
+
+		if (command === 'auth' && subcommand === 'status') {
+			if (parsed.json) printJson(io, getAuthStatusPayload());
+			else printHumanAuthStatus(io);
+			return 0;
+		}
+
+		if (command === 'auth' && subcommand === 'clear') {
+			const payload = clearAuth();
+			if (parsed.json) printJson(io, payload);
+			else io.stdout(`Cleared auth state at ${payload.userInfoPath}`);
+			return 0;
+		}
+
+		return printError(io, parsed.json, 'UNKNOWN_COMMAND', `Unknown command: ${parsed.args.join(' ') || command}`);
+	} catch (error) {
+		return printError(io, parsed.json, 'COMMAND_FAILED', error instanceof Error ? error.message : 'Command failed');
+	}
+};
+
+const entryFile = process.argv[1] ? resolveRealPath(process.argv[1]) : '';
+const currentFile = resolveRealPath(fileURLToPath(import.meta.url));
+if (entryFile === currentFile) {
+	void runCli().then(exitCode => {
+		process.exitCode = exitCode;
+	});
+}

--- a/src/config/user-info-store.ts
+++ b/src/config/user-info-store.ts
@@ -1,0 +1,33 @@
+import userInfoImport from './user-info';
+import type { UserInfo } from '../types';
+
+const createEmptyUserInfo = (): UserInfo => ({
+	loginUin: '',
+	uin: '',
+	cookie: '',
+	cookieList: [],
+	cookieObject: {},
+	refreshData: () => ({}),
+});
+
+export const setUserInfo = (userInfo: UserInfo): UserInfo => {
+	global.userInfo = userInfo || createEmptyUserInfo();
+	return global.userInfo;
+};
+
+export const initializeUserInfo = (userInfo: UserInfo = userInfoImport as UserInfo): UserInfo => setUserInfo(userInfo);
+
+export const getUserInfo = (): UserInfo => {
+	if (!global.userInfo) {
+		return initializeUserInfo();
+	}
+
+	return global.userInfo;
+};
+
+export const getUserCookie = (): string => getUserInfo().cookie || '';
+
+export const getUserUin = (fallback = '0'): string => {
+	const userInfo = getUserInfo();
+	return String(userInfo.uin || userInfo.loginUin || fallback);
+};

--- a/src/controllers/batchGetSongLists.ts
+++ b/src/controllers/batchGetSongLists.ts
@@ -3,6 +3,15 @@ import { songLists } from '../services';
 import { setApiResponse, withErrorHandler } from './util';
 import { customResponse } from '../util/apiResponse';
 
+interface SongListResponse {
+  code?: number | string;
+  data?: unknown;
+  [key: string]: unknown;
+}
+
+const isSongListResponse = (value: unknown): value is SongListResponse =>
+  Boolean(value && typeof value === 'object');
+
 const batchGetSongListsController = withErrorHandler(async (ctx: KoaContext) => {
   const { limit: ein = 19, page: sin = 0, sortId = 5, categoryIds = [10000000] } = ctx.request.body || {};
 
@@ -28,15 +37,16 @@ const batchGetSongListsController = withErrorHandler(async (ctx: KoaContext) => 
             categoryId
           }
         });
-        if (result.body.response && +result.body.response.code === 0) {
-          return result.body.response.data;
+        const response = result.body.response;
+        if (isSongListResponse(response) && Number(response.code) === 0) {
+          return response.data;
         } else {
-          return result.body.response;
+          return response;
         }
       }
     )
   );
-  
+
   setApiResponse(ctx, customResponse({ status: 200, data }, 200));
 });
 

--- a/src/controllers/cookies.ts
+++ b/src/controllers/cookies.ts
@@ -1,4 +1,5 @@
 import { Context, Next } from 'koa';
+import { getUserInfo } from '../config/user-info-store';
 
 /*
  * @Author: Rainy [https://github.com/rain120]
@@ -8,20 +9,21 @@ import { Context, Next } from 'koa';
  */
 export default {
 	get: async (ctx: Context, next: Next) => {
+		const userInfo = getUserInfo();
 		ctx.status = 200;
 		ctx.body = {
 			data: {
 				code: 200,
-				cookie: (global.userInfo as any).cookie,
-				cookieList: (global.userInfo as any).cookieList,
-				cookieObject: (global.userInfo as any).cookieObject
+				cookie: userInfo.cookie,
+				cookieList: userInfo.cookieList,
+				cookieObject: userInfo.cookieObject
 			}
 		};
 
 		await next();
 	},
 	set: async (ctx: Context, next: Next) => {
-		(ctx.request as any).cookies = global.userInfo.cookie;
+		(ctx.request as any).cookies = getUserInfo().cookie;
 		ctx.request.header['Access-Control-Allow-Origin'] = 'https://y.qq.com';
 		ctx.request.header['Access-Control-Allow-Methods'] = 'GET,PUT,POST,DELETE';
 		ctx.request.header['Access-Control-Allow-Headers'] = 'Content-Type';

--- a/src/controllers/util.ts
+++ b/src/controllers/util.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'koa';
 import type { KoaContext, Controller } from '../routes/types';
-import type { ApiResponse, ApiOptions } from '../types/api';
+import type { ApiResponse, ApiOptions, ApiResponseBody } from '../types/api';
 import {
 	logControllerFailure,
 	logControllerStart,
@@ -12,8 +12,9 @@ export interface Validator<T = Record<string, unknown>> {
 	(params: T): { valid: boolean; error?: string };
 }
 
-export interface ControllerOptions<T = Record<string, unknown>> {
+export interface ControllerOptions<T = Record<string, unknown>, TApiOptions extends ApiOptions = ApiOptions> {
 	validator?: Validator<T>;
+	buildApiOptions?: (ctx: KoaContext, params: T) => TApiOptions;
 	errorMessage?: string;
 	onError?: (ctx: KoaContext, error: unknown) => void;
 	name?: string;
@@ -36,7 +37,7 @@ const isMissingRequiredValue = (value: unknown): boolean => {
 
 export function createController<T extends ApiOptions>(
 	apiFunction: (props: T) => Promise<ApiResponse>,
-	options?: ControllerOptions<Record<string, unknown>>,
+	options?: ControllerOptions<Record<string, unknown>, T>,
 ): Controller {
 	return async (ctx: KoaContext, _next: () => Promise<void>) => {
 		const controllerName = options?.name || apiFunction.name || 'anonymous';
@@ -54,11 +55,13 @@ export function createController<T extends ApiOptions>(
 				}
 			}
 
-			const apiProps = {
-				method: 'get',
-				params,
-				option: {},
-			} as T;
+			const apiProps = options?.buildApiOptions
+				? options.buildApiOptions(ctx, params)
+				: ({
+						method: 'get',
+						params,
+						option: {},
+					} as T);
 
 			const { status, body } = await apiFunction(apiProps);
 			setJsonResponse(ctx, status, body);
@@ -84,7 +87,7 @@ export function validateRequired(fields: string[]): Validator {
 	};
 }
 
-export function setApiResponse(ctx: Context, apiResponse: ApiResponse): void {
+export function setApiResponse(ctx: Context, apiResponse: ApiResponse<ApiResponseBody>): void {
 	setJsonResponse(ctx, apiResponse.status || 500, apiResponse.body);
 }
 

--- a/src/koaApp.ts
+++ b/src/koaApp.ts
@@ -9,8 +9,7 @@ import securityHeaders from './middlewares/security-headers';
 import router from './routes/router';
 import cookieMiddleware from './util/cookie';
 import colors from './util/colors';
-import userInfoImport from './config/user-info';
-import type { UserInfo } from './types';
+import { initializeUserInfo } from './config/user-info-store';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -19,7 +18,7 @@ const publicDir = fs.existsSync(path.join(__dirname, 'public'))
 	? path.join(__dirname, 'public')
 	: path.join(__dirname, '..', 'public');
 
-global.userInfo = userInfoImport as UserInfo;
+initializeUserInfo();
 
 // Error handler (must be first) — catches downstream errors, sets response
 app.use(async (ctx, next) => {

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -1,93 +1,40 @@
 import { Router } from '@koa/router';
 import context from '../controllers';
-import { apiMetadata } from './api-metadata';
+import { apiMetadata, type ApiMetadataItem, type ApiMethod } from './api-metadata';
+import type { Controller } from './types';
 
 export { apiMetadata };
 
 const router = new Router();
+const controllers = context as Record<string, Controller>;
 
-// User
-router.get('/user/getCookie', context.getCookie);
-router.get('/user/setCookie', context.setCookie);
-router.get('/user/getUserPlaylists', context.getUserPlaylists);
-router.get('/user/getUserAvatar', context.getUserAvatar);
-router.get('/user/getUserLikedSongs', context.getUserLikedSongs);
+const getPaths = (item: ApiMetadataItem) => [item.path, ...(item.aliases || [])];
 
-// Download
-router.get('/downloadQQMusic', context.getDownloadQQMusic);
+const registerRoute = (method: ApiMethod, path: string, controller: Controller) => {
+	switch (method) {
+		case 'GET':
+			router.get(path, controller);
+			return;
+		case 'POST':
+			router.post(path, controller);
+			return;
+		case 'DELETE':
+			router.delete(path, controller);
+			return;
+		default: {
+			const exhaustiveMethod: never = method;
+			throw new Error(`Unsupported API method: ${exhaustiveMethod}`);
+		}
+	}
+};
 
-// Search
-router.get('/getHotkey', context.getHotKey);
-router.get('/getSearchByKey/:key', context.getSearchByKey);
-router.get('/getSearchByKey', context.getSearchByKey);
-router.get('/getSmartbox/:key', context.getSmartbox);
-router.get('/getSmartbox', context.getSmartbox);
+apiMetadata.forEach(item => {
+	const controller = controllers[item.name];
+	if (!controller) {
+		throw new Error(`Missing controller for API metadata item: ${item.name}`);
+	}
 
-// Song lists
-router.get('/getSongListCategories', context.getSongListCategories);
-router.get('/getSongLists/:page/:limit/:categoryId/:sortId', context.getSongLists);
-router.get('/getSongLists', context.getSongLists);
-router.post('/batchGetSongLists', context.batchGetSongLists);
-router.get('/getSongInfo/:songmid', context.getSongInfo);
-router.get('/getSongInfo', context.getSongInfo);
-router.post('/batchGetSongInfo', context.batchGetSongInfo);
-router.get('/getSongListDetail/:disstid', context.getSongListDetail);
-router.get('/getSongListDetail', context.getSongListDetail);
-router.get('/getNewDisks', context.getNewDisks);
-
-// MV
-router.get('/getMvByTag', context.getMvByTag);
-router.get('/getMv', context.getMv);
-router.get('/getMvPlay', context.getMvPlay);
-
-// Singer
-router.get('/getSingerList', context.getSingerList);
-router.get('/getSimilarSinger', context.getSimilarSinger);
-router.get('/getSingerAlbum', context.getSingerAlbum);
-router.get('/getSingerHotsong', context.getSingerHotsong);
-router.get('/getSingerMv', context.getSingerMv);
-router.get('/getSingerDesc', context.getSingerDesc);
-router.get('/getSingerStarNum', context.getSingerStarNum);
-
-// Radio & Digital Album
-router.get('/getRadioLists', context.getRadioLists);
-router.get('/getDigitalAlbumLists', context.getDigitalAlbumLists);
-
-// Music & Lyric
-router.get('/getLyric/:songmid', context.getLyric);
-router.get('/getLyric', context.getLyric);
-router.get('/getMusicPlay/:songmid', context.getMusicPlay);
-router.get('/getMusicPlay', context.getMusicPlay);
-router.get('/getAlbumInfo/:albummid', context.getAlbumInfo);
-router.get('/getAlbumInfo', context.getAlbumInfo);
-router.get('/getComments', context.getComments);
-
-// Recommend
-router.get('/getRecommend', context.getRecommend);
-router.get('/getTopLists', context.getTopLists);
-router.get('/getRanks', context.getRanks);
-
-// Utility
-router.get('/getTicketInfo', context.getTicketInfo);
-router.get('/getImageUrl', context.getImageUrl);
-
-// QQ Login
-router.get('/getQQLoginQr', context.getQQLoginQr);
-router.get('/user/getQQLoginQr', context.getQQLoginQr);
-router.post('/checkQQLoginQr', context.checkQQLoginQr);
-router.post('/user/checkQQLoginQr', context.checkQQLoginQr);
-
-// Personal recommend
-router.get('/getDailyRecommend', context.getDailyRecommend);
-router.get('/getPrivateFM', context.getPrivateFM);
-router.get('/getNewSongs', context.getNewSongs);
-router.get('/getPersonalRecommend', context.getPersonalRecommend);
-router.get('/getSimilarSongs', context.getSimilarSongs);
-
-// Extended features
-router.get('/getPlaylistTags', context.getPlaylistTags);
-router.get('/getPlaylistsByTag', context.getPlaylistsByTag);
-router.get('/getHotComments', context.getHotComments);
-router.get('/getSingerListByArea', context.getSingerListByArea);
+	getPaths(item).forEach(path => registerRoute(item.method, path, controller));
+});
 
 export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,81 @@
+import { styleText } from 'node:util';
+import colors from './util/colors';
+import serviceConfig from './config/service-config';
+import { getUserInfo } from './config/user-info-store';
+import app from './koaApp';
+import pkg from '../package.json';
+
+const parsedPort = Number.parseInt(process.env.PORT ?? '', 10);
+const PORT: number = Number.isFinite(parsedPort) ? parsedPort : 3200;
+
+export interface StartServerOptions {
+	port?: number;
+	json?: boolean;
+}
+
+export const startServer = (options: StartServerOptions = {}) => {
+	const port = options.port ?? PORT;
+
+	if (!options.json) {
+		console.log(styleText('green', '\n🎵 QQ Music API Service Starting...\n'));
+		console.log(colors.info(`Current Version: ${pkg.version}`));
+		console.log(colors.info(`Fallback Mode: ${serviceConfig.fallbackMode ? 'Enabled' : 'Disabled'}`));
+		console.log(colors.info(`Use Global Cookie: ${serviceConfig.useGlobalCookie ? 'Yes' : 'No'}`));
+
+		if (serviceConfig.fallbackMode) {
+			console.log(styleText('green', '\n✅ 降级模式已启用：支持手动传递 Cookie\n'));
+			console.log('使用方式:');
+			console.log('  1. Query 参数：GET /api/endpoint?cookie=your_cookie');
+			console.log('  2. Header: X-Custom-Cookie: your_cookie');
+			console.log('  3. Header: Cookie: your_cookie\n');
+		}
+
+		if (!serviceConfig.useGlobalCookie) {
+			console.log(styleText('yellow', '\n⚠️  全局 Cookie 未启用：需要登录的接口请手动传递 Cookie\n'));
+		} else {
+			console.log(styleText('green', '\n✅ 全局 Cookie 已启用\n'));
+			const userInfo = getUserInfo();
+
+			if (!(userInfo.loginUin || userInfo.uin)) {
+				console.log(
+					styleText(
+						'yellow',
+						`😔 The configuration ${styleText('red', 'loginUin')} or your ${styleText('red', 'cookie')} in file ${styleText('green', 'config/user-info')} has not configured. \n`,
+					),
+				);
+			}
+
+			if (!userInfo.cookie) {
+				console.log(
+					styleText(
+						'yellow',
+						`😔 The configuration ${styleText('red', 'cookie')} in file ${styleText('green', 'config/user-info')} has not configured. \n`,
+					),
+				);
+			}
+		}
+	}
+
+	const server = app.listen(port, () => {
+		if (options.json) {
+			console.log(JSON.stringify({ ok: true, command: 'serve', port }));
+			return;
+		}
+
+		console.log(colors.prompt(`server running @ http://localhost:${port}`));
+		console.log(colors.info(`open playground @ http://localhost:${port}/index.html`));
+	});
+
+	server.on('error', (error: NodeJS.ErrnoException) => {
+		if (error.code === 'EADDRINUSE') {
+			console.error(colors.error(`Port ${port} is already in use.`));
+			console.error(colors.warn('Stop the existing process or set PORT to another value before running again.'));
+			process.exit(1);
+		}
+
+		console.error(colors.error('Failed to start server.'));
+		console.error(error);
+		process.exit(1);
+	});
+	return server;
+};

--- a/src/services/apis/music/getLyric.ts
+++ b/src/services/apis/music/getLyric.ts
@@ -1,6 +1,7 @@
 import { lyricParse } from '../../../util/lyricParse';
 import y_common from '../y_common';
 import type { ApiOptions } from '../../../types/api';
+import { getUserUin } from '../../../config/user-info-store';
 import { extractUinFromCookie } from '../../../util/cookieResolver';
 import UCommon from '../UCommon/UCommon';
 import { observeService } from '../../../util/observability';
@@ -23,7 +24,7 @@ const getCookieFromOptions = (option: ApiOptions['option']): string | undefined 
 };
 
 const resolveUin = (cookie?: string): string => {
-  return extractUinFromCookie(cookie) || String((global as any).userInfo?.loginUin || '0');
+  return extractUinFromCookie(cookie) || getUserUin();
 };
 
 const decodeLyricField = (value: unknown): string => {

--- a/src/services/apis/music/getMusicPlay.ts
+++ b/src/services/apis/music/getMusicPlay.ts
@@ -1,6 +1,7 @@
 import type { Method } from 'axios';
 import UCommon from '../UCommon/UCommon';
 import { _guid } from '../../config';
+import { getUserUin } from '../../../config/user-info-store';
 import { extractCookieValue, extractUinFromCookie } from '../../../util/cookieResolver';
 import type { ApiOptions, ApiResponse } from '../../../types/api';
 
@@ -113,8 +114,7 @@ const buildPlayUrl = (domain: string, info: MidUrlInfo, guid: string): string =>
 };
 
 const resolveUin = (cookie?: string): string => {
-  const defaultUin = String((global as any).userInfo?.uin || (global as any).userInfo?.loginUin || '0');
-  return extractUinFromCookie(cookie) || defaultUin;
+  return extractUinFromCookie(cookie) || getUserUin();
 };
 
 const getCookieFromOptions = (option: ApiOptions['option']): string | undefined => {

--- a/src/services/apis/user/getUserLikedSongs.ts
+++ b/src/services/apis/user/getUserLikedSongs.ts
@@ -1,4 +1,5 @@
 import request from '../../../util/request';
+import { getUserInfo } from '../../../config/user-info-store';
 import { customResponse, errorResponse } from '../../../util/apiResponse';
 import type { ApiResponse } from '../../../types/api';
 
@@ -25,14 +26,16 @@ export const getUserLikedSongs = async (params: {
 	const url = 'https://c6.y.qq.com/rsc/fcgi-bin/fcg_get_profile_homepage.fcg';
 
 	try {
+		const userInfo = getUserInfo();
+
 		debugLog('request meta', {
 			url,
 			uin,
 			offset,
 			limit,
 			page,
-			hasGlobalCookie: Boolean(global.userInfo?.cookie),
-			cookieLength: global.userInfo?.cookie?.length || 0,
+			hasGlobalCookie: Boolean(userInfo.cookie),
+			cookieLength: userInfo.cookie?.length || 0,
 		});
 
 		const response = await request<Record<string, any>>({
@@ -62,7 +65,7 @@ export const getUserLikedSongs = async (params: {
 				},
 				headers: {
 					Referer: `https://y.qq.com/portal/profile.html?uin=${uin}`,
-					Cookie: global.userInfo?.cookie || '',
+					Cookie: userInfo.cookie || '',
 				},
 			},
 		});

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -1,6 +1,8 @@
+import { getUserUin } from '../config/user-info-store';
+
 export const getCommonParams = () => ({
 	g_tk: 1124214810,
-	loginUin: global.userInfo?.uin || '0',
+	loginUin: getUserUin(),
 	hostUin: 0,
 	inCharset: 'utf8',
 	outCharset: 'utf-8',

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,26 +1,40 @@
 /**
  * API 响应基础结构
  */
-export interface ApiResponse {
+export interface ApiResponseBody {
+  response?: unknown;
+  error?: unknown;
+  message?: string;
+  isOk?: boolean;
+  refresh?: boolean;
+  data?: unknown;
+  [key: string]: unknown;
+}
+
+export interface ApiSuccessBody<TData = unknown> extends ApiResponseBody {
+  response: TData;
+}
+
+export interface ApiErrorBody<TError = unknown> extends ApiResponseBody {
+  error: TError;
+}
+
+export interface ApiDataBody<TData = unknown> extends ApiResponseBody {
+  data: TData;
+}
+
+export interface ApiResponse<TBody extends ApiResponseBody = ApiResponseBody> {
   status: number;
-  body: {
-    response?: any;
-    error?: any;
-    message?: string;
-    isOk?: boolean;
-    refresh?: boolean;
-    data?: any;
-    [key: string]: any;
-  };
+  body: TBody;
 }
 
 /**
  * API 函数参数选项
  */
-export interface ApiOptions {
+export interface ApiOptions<TParams extends Record<string, any> = Record<string, any>, TOption = any> {
   method?: string;
-  params?: Record<string, any>;
-  option?: any;
+  params?: TParams;
+  option?: TOption;
   isFormat?: boolean | string;
   [key: string]: any;
 }
@@ -28,6 +42,7 @@ export interface ApiOptions {
 /**
  * API 函数类型定义
  */
-export type ApiFunction<T extends ApiOptions = ApiOptions> = (
-  options: T
-) => Promise<ApiResponse>;
+export type ApiFunction<
+  TOptions extends ApiOptions = ApiOptions,
+  TBody extends ApiResponseBody = ApiResponseBody
+> = (options: TOptions) => Promise<ApiResponse<TBody>>;

--- a/src/util/apiResponse.ts
+++ b/src/util/apiResponse.ts
@@ -1,4 +1,4 @@
-import type { ApiResponse } from '../types/api';
+import type { ApiErrorBody, ApiResponse, ApiResponseBody, ApiSuccessBody } from '../types/api';
 
 const INTERNAL_ERROR_MESSAGE = '服务器内部错误';
 
@@ -7,7 +7,7 @@ const INTERNAL_ERROR_MESSAGE = '服务器内部错误';
  * @param data 响应数据
  * @param status HTTP 状态码，默认 200
  */
-export function successResponse(data: any, status: number = 200): ApiResponse {
+export function successResponse<TData = unknown>(data: TData, status: number = 200): ApiResponse<ApiSuccessBody<TData>> {
 	return {
 		status,
 		body: {
@@ -21,7 +21,10 @@ export function successResponse(data: any, status: number = 200): ApiResponse {
  * @param error 错误信息
  * @param status HTTP 状态码，默认 500
  */
-export function errorResponse(error: any, status: number = 500): ApiResponse {
+export function errorResponse<TError = unknown>(
+	error: TError,
+	status: number = 500,
+): ApiResponse<ApiErrorBody<TError | string>> {
 	return {
 		status,
 		body: {
@@ -35,23 +38,23 @@ export function errorResponse(error: any, status: number = 500): ApiResponse {
  * @param promise API 请求 Promise
  * @param options 可选配置
  */
-export async function handleApi<T = any>(
+export async function handleApi<T = unknown, TData = unknown>(
 	promise: Promise<T>,
 	options?: {
 		/** 成功时的数据转换函数 */
-		transformData?: (data: T) => any;
+		transformData?: (data: T) => TData;
 		/** 自定义状态码 */
 		customStatus?: number;
 		/** 是否记录错误日志 */
 		logError?: boolean;
 	},
-): Promise<ApiResponse> {
+): Promise<ApiResponse<ApiSuccessBody<TData | T> | ApiErrorBody<string>>> {
 	try {
 		const result = await promise;
 		const resultAny = result as any;
-		const responseData = options?.transformData
-			? options.transformData(resultAny.data || result)
-			: resultAny.data || result;
+		const hasDataProperty = resultAny && typeof resultAny === 'object' && Object.prototype.hasOwnProperty.call(resultAny, 'data');
+		const rawData = hasDataProperty ? resultAny.data : result;
+		const responseData = options?.transformData ? options.transformData(rawData) : rawData;
 
 		return {
 			status: options?.customStatus || 200,
@@ -79,7 +82,10 @@ export async function handleApi<T = any>(
  * @param body 响应体
  * @param status HTTP 状态码
  */
-export function customResponse(body: any, status: number = 200): ApiResponse {
+export function customResponse<TBody extends ApiResponseBody = ApiResponseBody>(
+	body: TBody,
+	status: number = 200,
+): ApiResponse<TBody> {
 	return {
 		status,
 		body,
@@ -90,7 +96,7 @@ export function customResponse(body: any, status: number = 200): ApiResponse {
  * 处理 400 错误响应（参数错误）
  * @param message 错误消息
  */
-export function badRequest(message: string): ApiResponse {
+export function badRequest(message: string): ApiResponse<ApiSuccessBody<string>> {
 	return {
 		status: 400,
 		body: {

--- a/src/util/cookie.ts
+++ b/src/util/cookie.ts
@@ -1,6 +1,7 @@
 import { Context, Next, Middleware } from 'koa';
 import type { UserInfo } from '../types/global';
 import serviceConfig from '../config/service-config';
+import { getUserInfo } from '../config/user-info-store';
 import { resolveRequestCookie, setRequestCookieContext } from './cookieResolver';
 
 declare global {
@@ -30,8 +31,10 @@ const cookieMiddleware = (options: CookieMiddlewareOptions = {}): Middleware => 
     setRequestCookieContext(ctx, cookie);
   }
 
-  if (useGlobal && Array.isArray(global.userInfo?.cookieList)) {
-    global.userInfo.cookieList.forEach((cookieItem: string) => {
+  const userInfo = getUserInfo();
+
+  if (useGlobal && Array.isArray(userInfo.cookieList)) {
+    userInfo.cookieList.forEach((cookieItem: string) => {
       const [key, ...valueParts] = cookieItem.split('=');
       const normalizedKey = key?.trim();
       const value = valueParts.join('=').trim();

--- a/src/util/cookieResolver.ts
+++ b/src/util/cookieResolver.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'koa';
 import serviceConfig from '../config/service-config';
+import { getUserCookie } from '../config/user-info-store';
 
 type CookieSource =
   | 'query'
@@ -86,7 +87,7 @@ export const resolveRequestCookie = (
   }
 
   if (useGlobalCookie) {
-    const globalCookie = normalizeCookieValue(global.userInfo?.cookie);
+    const globalCookie = normalizeCookieValue(getUserCookie());
     if (globalCookie) {
       return { cookie: globalCookie, source: 'global' };
     }

--- a/tests/integration/package-entry.test.ts
+++ b/tests/integration/package-entry.test.ts
@@ -38,6 +38,13 @@ const runTsc = async (configPath: string) =>
 		timeout: 60_000,
 	});
 
+const getPackageBinEntry = () => {
+	const packageJson = JSON.parse(fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8')) as {
+		bin: Record<string, string>;
+	};
+	return path.join(projectRoot, packageJson.bin['qq-music-api']);
+};
+
 const writeTypesFixture = () => {
 	fs.rmSync(typesDir, { recursive: true, force: true });
 	fs.mkdirSync(typesDir, { recursive: true });
@@ -214,10 +221,7 @@ describe('Package Entry Compatibility', () => {
 	);
 
 	test('should emit a node shebang on the package bin entry', () => {
-		const packageJson = JSON.parse(fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8')) as {
-			bin: Record<string, string>;
-		};
-		const binEntry = path.join(projectRoot, packageJson.bin['qq-music-api']);
+		const binEntry = getPackageBinEntry();
 
 		expect(fs.readFileSync(binEntry, 'utf8')).toMatch(/^#!\/usr\/bin\/env node\n/);
 	});
@@ -226,7 +230,7 @@ describe('Package Entry Compatibility', () => {
 		'should start the CLI when invoked through a symlinked bin path',
 		async () => {
 			fs.mkdirSync(outputDir, { recursive: true });
-			const realEntry = path.join(projectRoot, 'dist', 'app.js');
+			const realEntry = getPackageBinEntry();
 			const symlinkEntry = path.join(outputDir, 'qq-music-api-bin.mjs');
 			fs.rmSync(symlinkEntry, { force: true });
 			fs.symlinkSync(realEntry, symlinkEntry);
@@ -235,6 +239,109 @@ describe('Package Entry Compatibility', () => {
 		},
 		60_000,
 	);
+
+	test('should print CLI help without starting the service', async () => {
+		const { stdout } = await runNode([getPackageBinEntry(), '--help']);
+
+		expect(stdout).toContain('qq-music-api config doctor');
+		expect(stdout).toContain('qq-music-api auth status');
+	});
+
+	test('should return config paths as JSON', async () => {
+		const { stdout } = await runNode([getPackageBinEntry(), 'config', 'path', '--json']);
+		const payload = JSON.parse(stdout);
+
+		expect(payload).toMatchObject({
+			ok: true,
+			command: 'config path',
+			configDir,
+			serviceConfigPath: path.join(configDir, 'service-config.json'),
+			userInfoPath: path.join(configDir, 'user-info.json'),
+		});
+	});
+
+	test('should reject missing CLI port values', async () => {
+		await expect(runNode([getPackageBinEntry(), 'config', 'path', '--port'])).rejects.toMatchObject({
+			code: 1,
+			stderr: expect.stringContaining('Missing value for --port'),
+		});
+	});
+
+	test('should reject partial CLI port values', async () => {
+		await expect(runNode([getPackageBinEntry(), 'config', 'path', '--port=3200abc'])).rejects.toMatchObject({
+			code: 1,
+			stderr: expect.stringContaining('Invalid port: 3200abc'),
+		});
+	});
+
+	test('should run config doctor as JSON without requiring auth', async () => {
+		const { stdout } = await runNode([getPackageBinEntry(), '--json', 'doctor']);
+		const payload = JSON.parse(stdout);
+
+		expect(payload).toMatchObject({
+			ok: true,
+			command: 'config doctor',
+			configDir,
+			writable: {
+				writable: true,
+			},
+			serviceConfig: {
+				status: 'missing',
+			},
+			userInfo: {
+				status: 'missing',
+			},
+		});
+	});
+
+	test('should report auth status without leaking cookie values', async () => {
+		fs.mkdirSync(configDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(configDir, 'user-info.json'),
+			JSON.stringify({
+				loginUin: 'o123456',
+				cookie: 'uin=o123456; qqmusic_key=secret-value',
+			}),
+			'utf-8',
+		);
+
+		const { stdout } = await runNode([getPackageBinEntry(), 'auth', 'status', '--json']);
+		const payload = JSON.parse(stdout);
+
+		expect(payload).toMatchObject({
+			ok: true,
+			command: 'auth status',
+			authenticated: true,
+			hasCookie: true,
+			cookieKeys: ['uin', 'qqmusic_key'],
+		});
+		expect(stdout).not.toContain('secret-value');
+	});
+
+	test('should clear auth state through the CLI', async () => {
+		fs.mkdirSync(configDir, { recursive: true });
+		const userInfoPath = path.join(configDir, 'user-info.json');
+		fs.writeFileSync(
+			userInfoPath,
+			JSON.stringify({
+				loginUin: 'o123456',
+				cookie: 'uin=o123456; qqmusic_key=secret-value',
+			}),
+			'utf-8',
+		);
+
+		const { stdout } = await runNode([getPackageBinEntry(), 'auth', 'clear', '--json']);
+		const payload = JSON.parse(stdout);
+		const userInfo = JSON.parse(fs.readFileSync(userInfoPath, 'utf-8'));
+
+		expect(payload).toMatchObject({
+			ok: true,
+			command: 'auth clear',
+			cleared: true,
+			userInfoPath,
+		});
+		expect(userInfo).toEqual({ loginUin: '', cookie: '' });
+	});
 
 	test(
 		'should expose Node16-compatible types for ESM import and CJS require consumers',

--- a/tests/unit/config/user-info-store.test.ts
+++ b/tests/unit/config/user-info-store.test.ts
@@ -1,0 +1,67 @@
+import type { UserInfo } from '../../../src/types';
+import {
+	getUserCookie,
+	getUserInfo,
+	getUserUin,
+	initializeUserInfo,
+	setUserInfo,
+} from '../../../src/config/user-info-store';
+
+const createUserInfo = (overrides: Partial<UserInfo> = {}): UserInfo => ({
+	loginUin: '123456',
+	uin: 'o123456',
+	cookie: 'uin=o123456; qqmusic_key=mock-key',
+	cookieList: ['uin=o123456', 'qqmusic_key=mock-key'],
+	cookieObject: {
+		uin: 'o123456',
+		qqmusic_key: 'mock-key',
+	},
+	refreshData: () => ({}),
+	...overrides,
+});
+
+describe('config/user-info-store', () => {
+	let originalUserInfo: UserInfo;
+
+	beforeEach(() => {
+		originalUserInfo = global.userInfo;
+	});
+
+	afterEach(() => {
+		global.userInfo = originalUserInfo;
+	});
+
+	test('should set and return the active user info', () => {
+		const userInfo = createUserInfo();
+
+		expect(setUserInfo(userInfo)).toBe(userInfo);
+		expect(getUserInfo()).toBe(userInfo);
+	});
+
+	test('should initialize global user info when missing', () => {
+		const userInfo = createUserInfo({ loginUin: '999', uin: 'o999' });
+		delete (global as Partial<typeof globalThis>).userInfo;
+
+		expect(initializeUserInfo(userInfo)).toBe(userInfo);
+		expect(getUserInfo()).toBe(userInfo);
+	});
+
+	test('should expose common cookie and uin accessors', () => {
+		setUserInfo(createUserInfo());
+
+		expect(getUserCookie()).toBe('uin=o123456; qqmusic_key=mock-key');
+		expect(getUserUin()).toBe('o123456');
+	});
+
+	test('should fall back from uin to loginUin', () => {
+		setUserInfo(createUserInfo({ uin: '' }));
+
+		expect(getUserUin()).toBe('123456');
+	});
+
+	test('should use caller fallback when both uin and loginUin are empty', () => {
+		setUserInfo(createUserInfo({ uin: '', loginUin: '' }));
+
+		expect(getUserUin('fallback-uin')).toBe('fallback-uin');
+	});
+});

--- a/tests/unit/controllers/util.test.ts
+++ b/tests/unit/controllers/util.test.ts
@@ -121,6 +121,49 @@ describe('controllers/util', () => {
       expect(mockApiFunction).toHaveBeenCalled();
     });
 
+    test('should allow custom API options mapping', async () => {
+      mockCtx.query = { id: '123' };
+      mockCtx.params = { kind: 'playlist' };
+      mockApiFunction.mockResolvedValue({ status: 200, body: {} });
+
+      const buildApiOptions = vi.fn((_ctx, params) => ({
+        method: 'post',
+        params,
+        option: {
+          headers: {
+            'x-test': '1'
+          }
+        }
+      }));
+
+      const controller = createController(mockApiFunction, { buildApiOptions });
+      await controller(mockCtx, mockNext);
+
+      expect(buildApiOptions).toHaveBeenCalledWith(mockCtx, { id: '123', kind: 'playlist' });
+      expect(mockApiFunction).toHaveBeenCalledWith({
+        method: 'post',
+        params: { id: '123', kind: 'playlist' },
+        option: {
+          headers: {
+            'x-test': '1'
+          }
+        }
+      });
+    });
+
+    test('should not build API options when validation fails', async () => {
+      const validator = vi.fn().mockReturnValue({ valid: false, error: 'Invalid' });
+      const buildApiOptions = vi.fn();
+      const controller = createController(mockApiFunction, { validator, buildApiOptions });
+
+      await controller(mockCtx, mockNext);
+
+      expect(buildApiOptions).not.toHaveBeenCalled();
+      expect(mockApiFunction).not.toHaveBeenCalled();
+      expect(mockCtx.status).toBe(400);
+      expect(mockCtx.body).toEqual({ response: 'Invalid' });
+    });
+
     test('should handle errors with custom onError handler', async () => {
       const onError = vi.fn();
       mockApiFunction.mockRejectedValue(new Error('API error'));

--- a/tests/unit/routes/api-metadata.test.ts
+++ b/tests/unit/routes/api-metadata.test.ts
@@ -1,10 +1,26 @@
 import { apiMetadata, apiMetadataPaths } from '../../../src/routes/api-metadata';
+import context from '../../../src/controllers';
 import router from '../../../src/routes/router';
+
+const IGNORED_ROUTER_METHODS = new Set(['HEAD', 'OPTIONS']);
 
 const getRoutePaths = () => {
 	const stack = (router as unknown as { stack: Array<{ path: string }> }).stack;
 	return new Set(stack.map(layer => layer.path));
 };
+
+const getRouteEntries = () => {
+	const stack = (router as unknown as { stack: Array<{ path: string; methods: string[] }> }).stack;
+
+	return stack.flatMap(layer =>
+		layer.methods
+			.filter(method => !IGNORED_ROUTER_METHODS.has(method))
+			.map(method => `${method} ${layer.path}`),
+	);
+};
+
+const getMetadataEntries = () =>
+	apiMetadata.flatMap(item => [item.path, ...(item.aliases || [])].map(path => `${item.method} ${path}`));
 
 describe('routes/api-metadata', () => {
 	test('should keep metadata paths in sync with registered routes', () => {
@@ -15,8 +31,28 @@ describe('routes/api-metadata', () => {
 		}
 	});
 
-	test('should avoid duplicate method and path entries', () => {
-		const keys = apiMetadata.map(item => `${item.method} ${item.path}`);
+	test('should document every registered route in metadata', () => {
+		const metadataEntries = new Set(getMetadataEntries());
+		const undocumentedRoutes = getRouteEntries().filter(routeEntry => !metadataEntries.has(routeEntry));
+
+		expect(undocumentedRoutes).toEqual([]);
+	});
+
+	test('should register exactly the method and path entries declared in metadata', () => {
+		expect(new Set(getRouteEntries())).toEqual(new Set(getMetadataEntries()));
+	});
+
+	test('should reference existing controllers', () => {
+		const controllerNames = new Set(Object.keys(context));
+		const missingControllers = apiMetadata
+			.filter(item => !controllerNames.has(item.name))
+			.map(item => item.name);
+
+		expect(missingControllers).toEqual([]);
+	});
+
+	test('should avoid duplicate method and path entries across paths and aliases', () => {
+		const keys = getMetadataEntries();
 		expect(new Set(keys).size).toBe(keys.length);
 	});
 });

--- a/tests/unit/util.test.ts
+++ b/tests/unit/util.test.ts
@@ -26,6 +26,15 @@ describe('util/apiResponse', () => {
     });
   });
 
+  it('errorResponse 应隐藏 500 Error 的内部消息', () => {
+    expect(errorResponse(new Error('private failure'), 500)).toEqual({
+      status: 500,
+      body: {
+        error: '服务器内部错误',
+      },
+    });
+  });
+
   it('customResponse 应原样返回自定义 body', () => {
     const body = { message: 'custom', extra: 1 };
 
@@ -65,6 +74,15 @@ describe('util/apiResponse', () => {
       status: 200,
       body: {
         response: payload,
+      },
+    });
+  });
+
+  it.each([0, false, '', null])('handleApi 应保留 data 字段的边界值: %s', async data => {
+    await expect(handleApi(Promise.resolve({ data }))).resolves.toEqual({
+      status: 200,
+      body: {
+        response: data,
       },
     });
   });

--- a/tests/unit/util/cookieResolver.test.ts
+++ b/tests/unit/util/cookieResolver.test.ts
@@ -1,6 +1,38 @@
-import { extractCookieValue, extractUinFromCookie } from '../../../src/util/cookieResolver';
+import type { UserInfo } from '../../../src/types';
+import {
+  extractCookieValue,
+  extractUinFromCookie,
+  resolveRequestCookie,
+} from '../../../src/util/cookieResolver';
+
+const createContext = (overrides: Record<string, unknown> = {}) => ({
+  query: {},
+  headers: {},
+  request: {},
+  ...overrides,
+}) as any;
 
 describe('util/cookieResolver cookie value parsing', () => {
+  let originalUserInfo: UserInfo;
+
+  beforeEach(() => {
+    originalUserInfo = global.userInfo;
+    global.userInfo = {
+      loginUin: '123456',
+      uin: 'o123456',
+      cookie: 'global_cookie=1',
+      cookieList: ['global_cookie=1'],
+      cookieObject: {
+        global_cookie: '1',
+      },
+      refreshData: () => ({}),
+    };
+  });
+
+  afterEach(() => {
+    global.userInfo = originalUserInfo;
+  });
+
   test('should extract a named cookie value', () => {
     expect(extractCookieValue('uin=o123456; qqmusic_key=mock-key', 'qqmusic_key')).toBe('mock-key');
   });
@@ -16,5 +48,60 @@ describe('util/cookieResolver cookie value parsing', () => {
 
   test('should reuse cookie value parsing for uin extraction', () => {
     expect(extractUinFromCookie('qqmusic_key=mock-key; uin=o123456')).toBe('o123456');
+  });
+
+  test('should prefer query cookie over headers, request, and global cookie', () => {
+    const result = resolveRequestCookie(
+      createContext({
+        query: { cookie: 'query_cookie=1' },
+        headers: {
+          'x-custom-cookie': 'custom_cookie=1',
+          cookie: 'header_cookie=1',
+        },
+        request: {
+          cookie: 'request_cookie=1',
+        },
+      }),
+      { fallbackMode: true, useGlobalCookie: true },
+    );
+
+    expect(result).toEqual({ cookie: 'query_cookie=1', source: 'query' });
+  });
+
+  test('should prefer x-custom-cookie over Cookie header when query cookie is missing', () => {
+    const result = resolveRequestCookie(
+      createContext({
+        headers: {
+          'x-custom-cookie': 'custom_cookie=1',
+          cookie: 'header_cookie=1',
+        },
+      }),
+      { fallbackMode: true, useGlobalCookie: true },
+    );
+
+    expect(result).toEqual({ cookie: 'custom_cookie=1', source: 'x-custom-cookie' });
+  });
+
+  test('should ignore query and header cookies when fallback mode is disabled', () => {
+    const result = resolveRequestCookie(
+      createContext({
+        query: { cookie: 'query_cookie=1' },
+        headers: { cookie: 'header_cookie=1' },
+        request: { cookie: 'request_cookie=1' },
+      }),
+      { fallbackMode: false, useGlobalCookie: true },
+    );
+
+    expect(result).toEqual({ cookie: 'request_cookie=1', source: 'request' });
+  });
+
+  test('should use global cookie only when explicitly enabled', () => {
+    expect(resolveRequestCookie(createContext(), { fallbackMode: false, useGlobalCookie: false })).toEqual({
+      source: 'none',
+    });
+    expect(resolveRequestCookie(createContext(), { fallbackMode: false, useGlobalCookie: true })).toEqual({
+      cookie: 'global_cookie=1',
+      source: 'global',
+    });
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,25 +4,34 @@ import { oxcTransform } from './plugins/vite-plugin-oxc-transform';
 import type { Plugin } from 'vite';
 
 function nodeBinShebang(): Plugin {
-	const appEntryId = normalizePath(resolve(__dirname, 'src/app.ts'));
+	const binEntryIds = new Set([
+		normalizePath(resolve(__dirname, 'src/app.ts')),
+		normalizePath(resolve(__dirname, 'src/cli.ts')),
+	]);
 
 	return {
 		name: 'node-bin-shebang',
 		generateBundle(_, bundle) {
-			const appChunk = Object.values(bundle).find(
-				(output) =>
-					output.type === 'chunk' &&
-					output.isEntry &&
-					output.facadeModuleId !== null &&
-					normalizePath(output.facadeModuleId) === appEntryId,
-			);
+			let locatedEntries = 0;
 
-			if (!appChunk || appChunk.type !== 'chunk') {
-				this.error(`Failed to locate the app entry chunk for ${appEntryId}`);
-			}
+			Object.values(bundle).forEach(output => {
+				if (
+					output.type !== 'chunk' ||
+					!output.isEntry ||
+					output.facadeModuleId === null ||
+					!binEntryIds.has(normalizePath(output.facadeModuleId))
+				) {
+					return;
+				}
 
-			if (!appChunk.code.startsWith('#!/usr/bin/env node')) {
-				appChunk.code = `#!/usr/bin/env node\n${appChunk.code}`;
+				locatedEntries += 1;
+				if (!output.code.startsWith('#!/usr/bin/env node')) {
+					output.code = `#!/usr/bin/env node\n${output.code}`;
+				}
+			});
+
+			if (locatedEntries !== binEntryIds.size) {
+				this.error(`Expected ${binEntryIds.size} bin entry chunks, found ${locatedEntries}.`);
 			}
 		},
 	};
@@ -36,6 +45,7 @@ export default defineConfig({
 		lib: {
 			entry: {
 				app: resolve(__dirname, 'src/app.ts'),
+				cli: resolve(__dirname, 'src/cli.ts'),
 				index: resolve(__dirname, 'src/index.ts'),
 			},
 			formats: ['es', 'cjs'],


### PR DESCRIPTION
## Summary

This PR tightens the framework boundaries around the QQ Music API service and adds a first-class CLI entry point while preserving the existing HTTP startup behavior.

## Problem

The project had several framework-level responsibilities spread across app startup, router registration, controller helpers, and global user-info access. The npm `bin` entry also behaved only as a service launcher, which made future CLI and MCP extension work harder to evolve safely. During review, the initial CLI port parser also accepted missing or partial port values, which could silently start the service with an unintended port.

## Root Cause

Startup concerns were coupled to `src/app.ts`, route registration duplicated metadata by hand, and cookie/user-info access relied directly on `global.userInfo` across modules. The CLI implementation originally used `Number.parseInt` and allowed `undefined` for `--port`, so invalid input was not rejected strictly.

## Changes

- Add `src/cli.ts` with `serve`, `config path`, `config doctor`, `doctor`, `auth status`, and `auth clear` commands.
- Preserve legacy no-argument `qq-music-api` behavior by routing it to the HTTP service startup.
- Move server startup into `src/server.ts` so `src/app.ts` remains a Koa app export with direct-execution support.
- Register HTTP routes from `apiMetadata` to keep route declarations and metadata synchronized.
- Add shared response typing improvements and controller API option mapping.
- Introduce `user-info-store` helpers to centralize user-info access.
- Split the agent instructions into focused docs under `docs/agent-instructions/`.
- Expand package-entry, route metadata, cookie resolver, controller helper, response helper, and user-info-store tests.
- Reject missing and partial CLI port values such as `--port` and `--port=3200abc`.

## Validation

- `npm run build`
- `npm run test` 401 tests passed
- `npm run lint`
- `npm run docs:build`
- `git diff --check` passed with only LF/CRLF warnings on Windows
