### PR TITLE
sync: bring main fixes back to dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ For code changes, run `npm run build && npm run test` before handoff. If docs ch
 
 - [Architecture and layering](docs/agent-instructions/architecture.md)
 - [Development workflow](docs/agent-instructions/development.md)
+- [Branching and merge rules](docs/agent-instructions/branching.md)
 - [Testing and validation](docs/agent-instructions/testing.md)
 - [Safety boundaries](docs/agent-instructions/safety.md)
 - [Release workflow](docs/agent-instructions/release.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.3.4 (2026-06-01)
+
+### Other Changes
+
+* promote dev changes to main (#20) ([add5156](https://github.com/sansenjian/qq-music-api/commit/add5156c2b91f1066196e9837dd8eb6719476e66))
+
+## 2.3.3 (2026-05-28)
+
+### Code Refactoring
+
+* complete structure migration (#17) ([da92126](https://github.com/sansenjian/qq-music-api/commit/da9212607e58e56772e427e71b41328629686f39))
+
 ## 2.3.2 (2026-05-22)
 
 ### Bug Fixes

--- a/docs/agent-instructions/branching.md
+++ b/docs/agent-instructions/branching.md
@@ -1,0 +1,85 @@
+# Branching and Merge Rules
+
+## Overview
+
+Use this file when creating branches, opening pull requests, or deciding how `dev` and `main` should move.
+
+## Branch Roles
+
+- `dev` is the integration branch for active development.
+- `main` is the stable release branch.
+- Feature, fix, refactor, test, and docs work must start from `dev`.
+- Ordinary development work should not open pull requests directly into `main`.
+
+## Development Flow
+
+1. Sync local `dev` from `origin/dev`.
+2. Create a topic branch from `dev`.
+3. Use a project-scoped branch name such as `feat/...`, `fix/...`, `refactor/...`, `docs/...`, `test/...`, `chore/...`, or `sync/...`.
+4. Implement and validate the change on the topic branch.
+5. Open a pull request back into `dev`.
+6. Merge into `dev` only after the expected checks and review pass.
+
+## Promoting Dev to Main
+
+When `dev` is stable, promote it through a pull request into `main`.
+
+Default flow:
+
+1. Sync `origin/dev` and `origin/main`.
+2. Open a pull request from `dev` into `main`.
+3. Confirm GitHub reports the pull request as mergeable.
+4. Run or wait for the required checks.
+5. Merge the pull request into `main`.
+
+Use this direct `dev -> main` pull request whenever it is clean and mergeable.
+
+## Conflict Flow
+
+Use a temporary sync branch only when `dev -> main` cannot be merged cleanly or needs manual conflict resolution.
+
+1. Sync `origin/main` and `origin/dev`.
+2. Create a sync branch from `origin/main`, for example `sync/dev-to-main`.
+3. Merge `origin/dev` into the sync branch.
+4. Resolve conflicts intentionally.
+5. Run required validation.
+6. Open a pull request from the sync branch into `main`.
+
+This is an exception path for conflicts, not the default release path.
+
+## After Main Changes
+
+If `main` receives changes that are not already in `dev`, bring them back to `dev`.
+
+Common examples:
+
+- version bumps
+- `CHANGELOG.md` updates
+- release workflow outputs
+- stable-branch hotfixes
+- conflict-resolution fixes made during a `dev -> main` promotion
+
+Use a small sync branch from `dev` and open a pull request back into `dev` when needed.
+
+## Conflict Resolution Policy
+
+- Preserve `main` release metadata when promoting to `main`, including version bumps, `CHANGELOG.md`, and release workflow outputs.
+- Preserve ESM/CJS package-entry fixes unless the replacement is a verified superset.
+- Preserve `dev` feature implementation when promoting stable work, including CLI, framework, route, and test improvements.
+- Do not downgrade `package.json` or `package-lock.json` versions during promotion.
+- Do not commit regenerated `docs/public/version.json` unless the task is explicitly a version or release update.
+- For package-entry changes, verify both ESM import and CJS require behavior with package-entry tests.
+
+## Hotfixes
+
+Emergency fixes may branch from `main` only when the user explicitly asks for a stable-branch hotfix.
+After merging a hotfix into `main`, backport or merge it into `dev` so future development does not lose the fix.
+
+## Validation
+
+Before opening a release or sync pull request, run:
+
+- `npm run build`
+- `npm run test`
+- `npm run lint`
+- `npm run docs:build` when docs changed

--- a/docs/public/version.json
+++ b/docs/public/version.json
@@ -1,7 +1,7 @@
 {
-  "version": "2.3.1",
+  "version": "2.3.4",
   "name": "@sansenjian/qq-music-api",
-  "generatedAt": "2026-05-21T13:26:46.479Z",
-  "commit": "ab6fa21",
+  "generatedAt": "2026-06-01T08:34:38.063Z",
+  "commit": "add5156",
   "branch": "main"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sansenjian/qq-music-api",
-	"version": "2.3.2",
+	"version": "2.3.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sansenjian/qq-music-api",
-			"version": "2.3.2",
+			"version": "2.3.4",
 			"license": "MIT",
 			"dependencies": {
 				"@koa/router": "^15.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sansenjian/qq-music-api",
-	"version": "2.3.2",
+	"version": "2.3.4",
 	"packageManager": "npm@11.14.1",
 	"publishConfig": {
 		"access": "public"

--- a/scripts/fix-cjs-declarations.js
+++ b/scripts/fix-cjs-declarations.js
@@ -5,4 +5,6 @@ const appDeclaration = "import type Koa = require('koa');\ndeclare const app: Ko
 writeFileSync('dist/app.d.cts', `${appDeclaration}export = app;\n`);
 writeFileSync('dist/index.d.cts', "import app = require('./app.cjs');\nexport = app;\n");
 writeFileSync('dist/app.d.mts', `${appDeclaration}export default app;\n`);
-writeFileSync('dist/index.d.mts', "export { default } from './app.mjs';\n");
+writeFileSync('dist/index.d.mts', "export { default } from './app.js';\n");
+writeFileSync('dist/app.d.ts', `${appDeclaration}export default app;\n`);
+writeFileSync('dist/index.d.ts', "export { default } from './app.js';\n");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,26 +12,31 @@ function nodeBinShebang(): Plugin {
 	return {
 		name: 'node-bin-shebang',
 		generateBundle(_, bundle) {
-			let locatedEntries = 0;
+			const locatedEntryIds = new Set<string>();
 
 			Object.values(bundle).forEach(output => {
 				if (
 					output.type !== 'chunk' ||
 					!output.isEntry ||
-					output.facadeModuleId === null ||
-					!binEntryIds.has(normalizePath(output.facadeModuleId))
+					output.facadeModuleId === null
 				) {
 					return;
 				}
 
-				locatedEntries += 1;
+				const facadeModuleId = normalizePath(output.facadeModuleId);
+				if (!binEntryIds.has(facadeModuleId)) {
+					return;
+				}
+
+				locatedEntryIds.add(facadeModuleId);
 				if (!output.code.startsWith('#!/usr/bin/env node')) {
 					output.code = `#!/usr/bin/env node\n${output.code}`;
 				}
 			});
 
-			if (locatedEntries !== binEntryIds.size) {
-				this.error(`Expected ${binEntryIds.size} bin entry chunks, found ${locatedEntries}.`);
+			const missingEntryIds = [...binEntryIds].filter(entryId => !locatedEntryIds.has(entryId));
+			if (missingEntryIds.length > 0) {
+				this.error(`Failed to locate bin entry chunks for: ${missingEntryIds.join(', ')}`);
 			}
 		},
 	};


### PR DESCRIPTION
## Summary
- sync main release metadata and ESM/CJS package-entry fixes back into dev
- add branching rules documenting the new dev-first workflow and direct dev -> main promotion path
- align package-lock root version with package.json at 2.3.4

## Validation
- npm run build
- npm run test
- npm run lint
- npm run docs:build

## Summary by Sourcery

将 dev 分支与 main 分支的最新修复同步，同时更新发布元数据和分支相关文档。

Bug Fixes（错误修复）:
- 确保在 Vite 构建插件中能够正确检测 Node bin 入口的 chunk，并按路径报告缺失的入口。
- 修正 ESM/CJS 的声明输出，使 TypeScript 的 `.d.ts` 和 `.d.mts` 入口点能够一致地引用构建后的 `.js` 文件。

Documentation（文档）:
- 记录以 dev 为主的分支与合并工作流，包括 dev→main 的提升流程、冲突处理方式以及热修复策略，并从 agent 指令索引中链接到该文档。

Chores（杂项）:
- 将包和锁文件版本提升到 2.3.4，并更新 2.3.3 和 2.3.4 版本的更新日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Synchronize dev with recent main-branch fixes while updating release metadata and branching documentation.

Bug Fixes:
- Ensure Node bin entry chunks are correctly detected and report missing entries by path in the Vite build plugin.
- Correct ESM/CJS declaration outputs so TypeScript .d.ts and .d.mts entry points reference the built .js files consistently.

Documentation:
- Document the dev-first branching and merge workflow, including dev→main promotion, conflict handling, and hotfix policies, and link it from the agent instructions index.

Chores:
- Bump package and lockfile version to 2.3.4 and update the changelog for the 2.3.3 and 2.3.4 releases.

</details>