### PR TITLE
feat: add mcp server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ npm run build
 # 生产运行
 npm run start
 
+# 启动 MCP Server（构建后）
+npm run mcp
+
 # 运行测试
 npm run test
 
@@ -102,8 +105,10 @@ npm run docs:dev
 | 依赖          | 说明        |
 | ------------- | ----------- |
 | `@koa/router` | 路由        |
+| `@modelcontextprotocol/sdk` | MCP Server SDK |
 | `axios`       | HTTP 客户端 |
 | `koa`         | Web 框架    |
+| `zod`         | MCP 工具参数校验 |
 
 ### 开发依赖
 
@@ -153,6 +158,12 @@ npm run docs:dev
 - 首页推荐
 - 下载地址
 - 票务信息
+
+### MCP 与 CLI
+
+- `qq-music-api mcp start` 可通过 stdio 启动 MCP Server
+- `qq_music_search_songs`、`qq_music_get_top_lists`、`qq_music_get_playlist_detail` 等工具复用现有 service 层
+- `qq_music_auth_status` 只返回登录态摘要和 Cookie key，不返回完整 Cookie 值
 
 ## 文档入口
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -15,7 +15,7 @@ title: 使用指南
 - **[降级服务示例](/DEGRADE_EXAMPLES)**：手动传递 Cookie、Header 调用和多语言示例
 - **[配置规范](/guide/configuration-policy)**：配置目录、写入时机和环境变量边界
 - **[依赖分析](/guide/dependency-inspection)**：使用依赖分析工具观察依赖体积与优化空间
-- **[MCP 与 CLI 拓展思考](/guide/mcp-cli-extension)**：未来命令行与 MCP Server 的职责划分
+- **[MCP 与 CLI 拓展](/guide/mcp-cli-extension)**：命令行与 MCP Server 的职责划分
 - **[代码架构](/guide/architecture)**：项目分层与 TypeScript 抽象说明
 
 ## 推荐阅读顺序
@@ -43,7 +43,7 @@ title: 使用指南
 
 - [配置规范](/guide/configuration-policy) - 配置文件、环境变量和写入副作用边界
 - [依赖分析](/guide/dependency-inspection) - 依赖体积、依赖树和优化线索检查
-- [MCP 与 CLI 拓展思考](/guide/mcp-cli-extension) - 后续工具化方向与风险边界
+- [MCP 与 CLI 拓展](/guide/mcp-cli-extension) - 工具化方向与风险边界
 - [代码架构](/guide/architecture) - 当前目录结构、抽象方式与重构结果
 
 ## 项目特性概览

--- a/docs/guide/mcp-cli-extension.md
+++ b/docs/guide/mcp-cli-extension.md
@@ -1,15 +1,15 @@
 ---
 layout: doc
-title: MCP 与 CLI 拓展思考
+title: MCP 与 CLI 拓展
 ---
 
-# MCP 与 CLI 拓展思考
+# MCP 与 CLI 拓展
 
-本文记录 QQ Music API 在 MCP 和 CLI 方向上的拓展思路。它不是当前功能承诺，而是后续设计和评审时的边界参考。
+本文记录 QQ Music API 在 MCP 和 CLI 方向上的当前能力、使用方式和后续边界。
 
 ## 背景
 
-项目当前主要能力是 Koa HTTP API 服务，同时 npm 包中存在 `bin` 入口，可用于启动服务。这个入口更接近“服务启动器”，还不是完整 CLI。
+项目当前主要能力是 Koa HTTP API 服务，同时 npm 包中存在 `bin` 入口，可用于启动 HTTP 服务、查询本地配置状态，并通过 stdio 启动 MCP Server。
 
 如果继续扩展，应避免把 HTTP 服务、命令行工具和 MCP Server 混在一个入口里。三者可以共享底层模块，但运行边界要清晰。
 
@@ -25,6 +25,7 @@ qq-music-api config doctor
 qq-music-api doctor
 qq-music-api auth status
 qq-music-api auth clear
+qq-music-api mcp start
 ```
 
 说明：
@@ -33,19 +34,71 @@ qq-music-api auth clear
 - `serve` 支持 `--port <port>` 和 `--json`。
 - `config path`、`config doctor`、`doctor`、`auth status`、`auth clear` 支持 `--json`。
 - `auth status` 不输出完整 Cookie，只输出登录态是否存在和 Cookie key 列表。
-- MCP Server 尚未实现，仍属于后续扩展方向。
+- `mcp start` 通过 stdio 启动 MCP Server，供支持 MCP 的本地客户端以子进程方式连接。
+
+## 当前 MCP 状态
+
+当前 MCP Server 使用 `@modelcontextprotocol/sdk` 的 stdio transport，入口如下：
+
+```bash
+qq-music-api mcp start
+```
+
+本地源码开发可用：
+
+```bash
+npm run mcp:dev
+```
+
+构建后可用：
+
+```bash
+npm run build
+npm run mcp
+```
+
+MCP 客户端可以使用类似配置：
+
+```json
+{
+  "mcpServers": {
+    "qq-music-api": {
+      "command": "qq-music-api",
+      "args": ["mcp", "start"],
+      "env": {
+        "QQ_MUSIC_API_CONFIG_DIR": "/path/to/config"
+      }
+    }
+  }
+}
+```
+
+已提供的工具：
+
+| 工具 | 说明 | 凭据行为 |
+| --- | --- | --- |
+| `qq_music_config_status` | 输出配置目录和配置文件路径 | 不读取 Cookie 值 |
+| `qq_music_auth_status` | 输出登录态摘要和 Cookie key 列表 | 不返回 Cookie 值 |
+| `qq_music_list_apis` | 分页列出 HTTP API 目录 | 只读本地元数据 |
+| `qq_music_get_hot_keys` | 获取搜索热词 | 调用公开上游接口 |
+| `qq_music_search_songs` | 按关键词搜索歌曲 | 调用公开上游接口 |
+| `qq_music_get_top_lists` | 获取排行榜列表 | 调用公开上游接口 |
+| `qq_music_get_playlist_detail` | 按 `disstid` 获取歌单详情 | 调用公开上游接口 |
+| `qq_music_get_album_info` | 按 `albummid` 获取专辑信息 | 调用公开上游接口 |
+
+所有工具默认返回 Markdown 文本，同时提供 `structuredContent`。支持 `response_format: "json"` 时，会返回适合机器处理的 JSON 文本。
 
 ## 目标
 
-后续拓展可以围绕三个方向推进：
+后续拓展继续围绕三个方向推进：
 
 - CLI：提供本地开发、配置检查、登录态管理、服务启动等命令。
-- MCP Server：让支持 MCP 的客户端以工具方式调用音乐搜索、歌单、排行等能力。
+- MCP Server：继续扩展工具覆盖面，让支持 MCP 的客户端以工具方式调用音乐搜索、歌单、排行等能力。
 - SDK/包入口：继续保持 `import` 使用时的低副作用和可组合性。
 
 ## 非目标
 
-短期不建议做这些事：
+不建议做这些事：
 
 - 不把 CLI 做成另一个 HTTP 框架。
 - 不在 MCP 工具中直接暴露 Cookie 或登录态原文。
@@ -107,7 +160,7 @@ qq-music-api config doctor --json
 
 ### 工具边界
 
-MCP 工具应优先覆盖无需敏感凭据或可安全降级的能力：
+MCP 工具优先覆盖无需敏感凭据或可安全降级的能力：
 
 - 搜索歌曲。
 - 获取排行榜。
@@ -125,11 +178,11 @@ MCP 工具应优先覆盖无需敏感凭据或可安全降级的能力：
 - 错误返回使用通用错误码和可读消息，不泄露内部异常。
 - 工具实现复用 `src/services/` 层能力，不直接调用 Koa `ctx`。
 
-示例工具草案：
+示例工具：
 
 ```ts
 {
-  name: 'search_songs',
+  name: 'qq_music_search_songs',
   description: 'Search QQ Music songs by keyword.',
   inputSchema: {
     keyword: 'string',
@@ -171,9 +224,9 @@ MCP Server 如果需要读取登录态，只能读取运行进程可访问的配
 1. 先抽出配置解析和写入模块，消除 import 阶段写盘副作用。
 2. 增加 `serve`、`config path`、`config doctor` 三个最小 CLI 命令。
 3. 将当前 bin 从“直接启动服务”过渡到 `serve` 默认命令，保持兼容。
-4. 为公开 API 能力设计第一批 MCP 工具。
-5. 增加 MCP 工具测试，覆盖 schema、成功响应和错误响应。
-6. 再评估是否支持登录态相关 MCP 工具。
+4. 已为公开 API 能力设计第一批 MCP 工具。
+5. 已增加 MCP 工具测试，覆盖 schema、成功响应和错误响应。
+6. 后续再评估是否支持登录态相关 MCP 工具。
 
 ## 风险与约束
 
@@ -188,7 +241,6 @@ MCP Server 如果需要读取登录态，只能读取运行进程可访问的配
 ## 开放问题
 
 - CLI 是否引入命令解析库，还是先用轻量原生命令解析。
-- MCP Server 是否作为主包能力发布，还是拆成独立包。
 - 登录态相关 MCP 工具是否默认禁用。
 - 是否需要为配置目录提供跨平台默认路径。
 - 是否为所有工具提供 HTTP 路由到 MCP 工具的映射表。

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
 			"license": "MIT",
 			"dependencies": {
 				"@koa/router": "^15.5.0",
+				"@modelcontextprotocol/sdk": "^1.29.0",
 				"axios": "^1.16.1",
-				"koa": "^2.16.4"
+				"koa": "^2.16.4",
+				"zod": "^4.4.3"
 			},
 			"bin": {
 				"qq-music-api": "dist/cli.js"
@@ -365,29 +367,6 @@
 			"version": "4.6.2",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@emnapi/core": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.1",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
 			"version": "1.2.1",
@@ -840,6 +819,18 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@hono/node-server": {
+			"version": "1.19.14",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.14.1"
+			},
+			"peerDependencies": {
+				"hono": "^4"
+			}
+		},
 		"node_modules/@iconify-json/simple-icons": {
 			"version": "1.2.72",
 			"dev": true,
@@ -892,6 +883,46 @@
 			},
 			"peerDependenciesMeta": {
 				"koa": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.29.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+			"integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@hono/node-server": "^1.19.9",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
 					"optional": false
 				}
 			}
@@ -2690,7 +2721,6 @@
 		},
 		"node_modules/ajv": {
 			"version": "8.20.0",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -2701,6 +2731,23 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/ansi-escapes": {
@@ -2849,6 +2896,95 @@
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
+		"node_modules/body-parser": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "^3.1.2",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.0",
+				"iconv-lite": "^0.7.0",
+				"on-finished": "^2.4.1",
+				"qs": "^6.14.1",
+				"raw-body": "^3.0.1",
+				"type-is": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/body-parser/node_modules/media-typer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/body-parser/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/body-parser/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/body-parser/node_modules/type-is": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+			"license": "MIT",
+			"dependencies": {
+				"content-type": "^2.0.0",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/body-parser/node_modules/type-is/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/brace-expansion": {
 			"version": "5.0.6",
 			"dev": true,
@@ -2885,6 +3021,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/cac": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
@@ -2919,7 +3064,6 @@
 		},
 		"node_modules/call-bound": {
 			"version": "1.0.4",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
@@ -3230,6 +3374,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/cookie-es": {
 			"version": "1.2.3",
 			"dev": true,
@@ -3237,7 +3390,6 @@
 		},
 		"node_modules/cookie-signature": {
 			"version": "1.2.2",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.6.0"
@@ -3257,6 +3409,23 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/cosmiconfig": {
@@ -3299,6 +3468,20 @@
 				"@types/node": "*",
 				"cosmiconfig": ">=9",
 				"typescript": ">=5"
+			}
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/crossws": {
@@ -3636,10 +3819,40 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/eventemitter3": {
 			"version": "5.0.4",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/eventsource": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+			"license": "MIT",
+			"dependencies": {
+				"eventsource-parser": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+			"integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
 		},
 		"node_modules/expect-type": {
 			"version": "1.3.0",
@@ -3647,6 +3860,185 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/express": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express-rate-limit": {
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+			"integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^10.2.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
+		"node_modules/express/node_modules/accepts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/express/node_modules/content-disposition": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express/node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/express/node_modules/fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/express/node_modules/media-typer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/express/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/express/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express/node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/express/node_modules/type-is": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+			"license": "MIT",
+			"dependencies": {
+				"content-type": "^2.0.0",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express/node_modules/type-is/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/exsolve": {
@@ -3658,7 +4050,6 @@
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-npm-meta": {
@@ -3679,7 +4070,6 @@
 		},
 		"node_modules/fast-uri": {
 			"version": "3.1.2",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -3701,6 +4091,36 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/finalhandler": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/finalhandler/node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/focus-trap": {
@@ -3758,6 +4178,15 @@
 			},
 			"funding": {
 				"url": "https://ko-fi.com/tunnckoCore/commissions"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/fresh": {
@@ -3976,6 +4405,16 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/hono": {
+			"version": "4.12.23",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+			"integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
 		"node_modules/hookable": {
 			"version": "5.5.3",
 			"dev": true,
@@ -4079,6 +4518,22 @@
 				"url": "https://github.com/sponsors/typicode"
 			}
 		},
+		"node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/ignore-by-default": {
 			"version": "1.0.1",
 			"dev": true,
@@ -4126,6 +4581,24 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/ip-address": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/iron-webcrypto": {
@@ -4267,6 +4740,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"license": "MIT"
+		},
 		"node_modules/is-wsl": {
 			"version": "3.1.1",
 			"dev": true,
@@ -4280,6 +4759,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"license": "ISC"
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.2",
@@ -4322,6 +4807,15 @@
 				"jiti": "lib/jiti-cli.mjs"
 			}
 		},
+		"node_modules/jose": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"dev": true,
@@ -4345,8 +4839,13 @@
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "1.0.0",
-			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/keygrip": {
 			"version": "1.1.0",
@@ -4914,6 +5413,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/methods": {
 			"version": "1.1.2",
 			"dev": true,
@@ -5279,9 +5790,17 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/object-inspect": {
 			"version": "1.13.4",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -5326,7 +5845,6 @@
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
@@ -5517,6 +6035,15 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/path-to-regexp": {
 			"version": "8.4.2",
 			"license": "MIT",
@@ -5549,6 +6076,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pkce-challenge": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/pkg-types": {
@@ -5624,6 +6160,19 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"license": "MIT",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
 		"node_modules/proxy-from-env": {
 			"version": "2.1.0",
 			"license": "MIT",
@@ -5662,7 +6211,6 @@
 			"version": "6.15.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
 			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
-			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"
@@ -5693,6 +6241,30 @@
 			"version": "1.1.2",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
 		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
@@ -5736,7 +6308,6 @@
 		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -5965,6 +6536,22 @@
 			"dev": true,
 			"optional": true
 		},
+		"node_modules/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
 		"node_modules/run-applescript": {
 			"version": "7.1.0",
 			"dev": true,
@@ -6007,6 +6594,12 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
+		},
 		"node_modules/semver": {
 			"version": "7.8.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
@@ -6020,9 +6613,127 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/send/node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/send/node_modules/fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/send/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/send/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/serve-static": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/serve-static/node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/setprototypeof": {
 			"version": "1.2.0",
 			"license": "ISC"
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/shell-quote": {
 			"version": "1.8.3",
@@ -6052,7 +6763,6 @@
 		},
 		"node_modules/side-channel": {
 			"version": "1.1.0",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -6070,7 +6780,6 @@
 		},
 		"node_modules/side-channel-list": {
 			"version": "1.0.0",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -6085,7 +6794,6 @@
 		},
 		"node_modules/side-channel-map": {
 			"version": "1.0.1",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -6102,7 +6810,6 @@
 		},
 		"node_modules/side-channel-weakmap": {
 			"version": "1.0.2",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -7116,6 +7823,15 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/unstorage": {
 			"version": "1.17.5",
 			"dev": true,
@@ -7625,6 +8341,21 @@
 				}
 			}
 		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/why-is-node-running": {
 			"version": "2.3.0",
 			"dev": true,
@@ -7710,7 +8441,6 @@
 		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/ws": {
@@ -7841,6 +8571,25 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
 			}
 		},
 		"node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
 		"dev": "tsx src/app.ts",
 		"build": "vite build && tsc --emitDeclarationOnly && node scripts/fix-cjs-declarations.js",
 		"start": "node dist/app.js",
+		"mcp": "node dist/cli.js mcp start",
+		"mcp:dev": "tsx src/cli.ts mcp start",
 		"vercel-build": "npm run build && npm run docs:build && (cp -r public dist/ 2>/dev/null || true)",
 		"docs:build": "node scripts/generate-version.js && vitepress build docs",
 		"test": "vitest run",
@@ -111,8 +113,10 @@
 	"homepage": "https://github.com/sansenjian/qq-music-api#readme",
 	"dependencies": {
 		"@koa/router": "^15.5.0",
+		"@modelcontextprotocol/sdk": "^1.29.0",
 		"axios": "^1.16.1",
-		"koa": "^2.16.4"
+		"koa": "^2.16.4",
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^20.5.3",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { getConfigDir, resolveConfigPath } from './config/config-path';
 import { getUserInfo, setUserInfo } from './config/user-info-store';
 import type { UserInfo } from './types';
+import { getCookieKeys } from './util/cookieResolver';
 import pkg from '../package.json';
 
 interface CliIo {
@@ -109,6 +110,7 @@ const redirectConsoleOutputToStderr = (): (() => void) => {
 	const originalLog = console.log;
 	const originalInfo = console.info;
 	const originalWarn = console.warn;
+	const originalDebug = console.debug;
 	const stderrLog = (...args: unknown[]) => {
 		console.error(...args);
 	};
@@ -116,11 +118,13 @@ const redirectConsoleOutputToStderr = (): (() => void) => {
 	console.log = stderrLog;
 	console.info = stderrLog;
 	console.warn = stderrLog;
+	console.debug = stderrLog;
 
 	return () => {
 		console.log = originalLog;
 		console.info = originalInfo;
 		console.warn = originalWarn;
+		console.debug = originalDebug;
 	};
 };
 
@@ -174,21 +178,6 @@ const readJsonFileStatus = (filePath: string): JsonFileStatus => {
 			error: error instanceof Error ? error.message : 'Invalid JSON',
 		};
 	}
-};
-
-const getCookieKeys = (cookie: string | undefined): string[] => {
-	if (!cookie) return [];
-	return cookie
-		.split(';')
-		.map(item => item.trim())
-		.filter(Boolean)
-		.flatMap(item => {
-			const separatorIndex = item.indexOf('=');
-			if (separatorIndex <= 0) return [];
-
-			const key = item.slice(0, separatorIndex).trim();
-			return key ? [key] : [];
-		});
 };
 
 const checkWritable = (configDir: string) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,6 +105,25 @@ const printError = (io: CliIo, json: boolean, code: string, message: string): nu
 	return 1;
 };
 
+const redirectConsoleOutputToStderr = (): (() => void) => {
+	const originalLog = console.log;
+	const originalInfo = console.info;
+	const originalWarn = console.warn;
+	const stderrLog = (...args: unknown[]) => {
+		console.error(...args);
+	};
+
+	console.log = stderrLog;
+	console.info = stderrLog;
+	console.warn = stderrLog;
+
+	return () => {
+		console.log = originalLog;
+		console.info = originalInfo;
+		console.warn = originalWarn;
+	};
+};
+
 const helpText = () => `QQ Music API CLI
 
 Usage:
@@ -163,8 +182,13 @@ const getCookieKeys = (cookie: string | undefined): string[] => {
 		.split(';')
 		.map(item => item.trim())
 		.filter(Boolean)
-		.map(item => item.slice(0, item.indexOf('=')).trim())
-		.filter(Boolean);
+		.flatMap(item => {
+			const separatorIndex = item.indexOf('=');
+			if (separatorIndex <= 0) return [];
+
+			const key = item.slice(0, separatorIndex).trim();
+			return key ? [key] : [];
+		});
 };
 
 const checkWritable = (configDir: string) => {
@@ -317,8 +341,13 @@ export const runCli = async (argv: string[] = process.argv.slice(2), io: CliIo =
 		}
 
 		if (command === 'mcp' && (subcommand === 'start' || subcommand === undefined)) {
-			const { runMcpServer } = await import('./mcp/server');
-			await runMcpServer();
+			const restoreConsoleOutput = redirectConsoleOutputToStderr();
+			try {
+				const { runMcpServer } = await import('./mcp/server');
+				await runMcpServer();
+			} finally {
+				restoreConsoleOutput();
+			}
 			return 0;
 		}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -114,6 +114,7 @@ Usage:
   qq-music-api doctor [--json]
   qq-music-api auth status [--json]
   qq-music-api auth clear [--json]
+  qq-music-api mcp start
 
 Options:
   --json             Output stable machine-readable JSON for supported commands.
@@ -124,6 +125,7 @@ Options:
 Notes:
   Running qq-music-api with no command keeps the legacy behavior and starts the HTTP service.
   Auth commands never print the full Cookie value.
+  MCP uses stdio; do not pipe normal logs to stdout while it is running.
 `;
 
 const getPathPayload = () => {
@@ -311,6 +313,12 @@ export const runCli = async (argv: string[] = process.argv.slice(2), io: CliIo =
 			const payload = clearAuth();
 			if (parsed.json) printJson(io, payload);
 			else io.stdout(`Cleared auth state at ${payload.userInfoPath}`);
+			return 0;
+		}
+
+		if (command === 'mcp' && (subcommand === 'start' || subcommand === undefined)) {
+			const { runMcpServer } = await import('./mcp/server');
+			await runMcpServer();
 			return 0;
 		}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -342,11 +342,18 @@ export const runCli = async (argv: string[] = process.argv.slice(2), io: CliIo =
 
 		if (command === 'mcp' && (subcommand === 'start' || subcommand === undefined)) {
 			const restoreConsoleOutput = redirectConsoleOutputToStderr();
+			const restoreOnProcessExit = () => {
+				restoreConsoleOutput();
+			};
+			process.once('exit', restoreOnProcessExit);
+
 			try {
 				const { runMcpServer } = await import('./mcp/server');
 				await runMcpServer();
-			} finally {
+			} catch (error) {
+				process.off('exit', restoreOnProcessExit);
 				restoreConsoleOutput();
+				throw error;
 			}
 			return 0;
 		}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -40,18 +40,7 @@ export const createQqMusicMcpServer = (options: CreateQqMusicMcpServerOptions = 
 	return server;
 };
 
-const redirectConsoleLogToStderr = () => {
-	const stderrLog = (...args: unknown[]) => {
-		console.error(...args);
-	};
-
-	console.log = stderrLog;
-	console.info = stderrLog;
-	console.warn = stderrLog;
-};
-
 export const runMcpServer = async (): Promise<void> => {
-	redirectConsoleLogToStderr();
 	const server = createQqMusicMcpServer();
 	const transport = new StdioServerTransport();
 	await server.connect(transport);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,59 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { apiMetadata } from '../routes/api-metadata';
+import pkg from '../../package.json';
+import { registerQqMusicMcpTools } from './tools';
+import type { QqMusicMcpServices } from './tools';
+
+interface CreateQqMusicMcpServerOptions {
+	services?: QqMusicMcpServices;
+}
+
+const SERVER_NAME = 'qq-music-api-mcp-server';
+
+export const createQqMusicMcpServer = (options: CreateQqMusicMcpServerOptions = {}): McpServer => {
+	const server = new McpServer({
+		name: SERVER_NAME,
+		version: pkg.version,
+	});
+
+	registerQqMusicMcpTools(server, options.services);
+	server.registerResource(
+		'qq_music_api_catalog',
+		'qq-music://api-catalog',
+		{
+			title: 'QQ Music API Catalog',
+			description: 'Static catalog of QQ Music API HTTP routes exposed by this package.',
+			mimeType: 'application/json',
+		},
+		async uri => ({
+			contents: [
+				{
+					uri: uri.href,
+					mimeType: 'application/json',
+					text: JSON.stringify(apiMetadata, null, 2),
+				},
+			],
+		}),
+	);
+
+	return server;
+};
+
+const redirectConsoleLogToStderr = () => {
+	const stderrLog = (...args: unknown[]) => {
+		console.error(...args);
+	};
+
+	console.log = stderrLog;
+	console.info = stderrLog;
+	console.warn = stderrLog;
+};
+
+export const runMcpServer = async (): Promise<void> => {
+	redirectConsoleLogToStderr();
+	const server = createQqMusicMcpServer();
+	const transport = new StdioServerTransport();
+	await server.connect(transport);
+	console.error(`${SERVER_NAME} running on stdio`);
+};

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -12,16 +12,18 @@ import {
 	songListDetail,
 } from '../services';
 import type { ApiResponse } from '../types/api';
+import { getCookieKeys } from '../util/cookieResolver';
 
 const CHARACTER_LIMIT = 24_000;
 const ERROR_MESSAGE_LIMIT = 2_000;
 
-const responseFormatSchema = z
+const responseFormatField = z
 	.enum(['markdown', 'json'])
 	.default('markdown')
 	.describe("Response format. Use 'markdown' for readable summaries or 'json' for structured output.");
 
-const mcpOutputSchema = {
+// The MCP SDK accepts Zod raw shapes here and serializes them to JSON Schema in listTools.
+const mcpOutputShape = {
 	ok: z.boolean(),
 	tool: z.string(),
 	status: z.number().optional(),
@@ -196,22 +198,6 @@ const serviceResult = (
 	return createToolResult(payload, responseFormat, jsonBlock(title, data));
 };
 
-const cookieKeys = (cookie: string | undefined): string[] => {
-	if (!cookie) return [];
-
-	return cookie
-		.split(';')
-		.map(item => item.trim())
-		.filter(Boolean)
-		.flatMap(item => {
-			const separatorIndex = item.indexOf('=');
-			if (separatorIndex <= 0) return [];
-
-			const key = item.slice(0, separatorIndex).trim();
-			return key ? [key] : [];
-		});
-};
-
 const apiCatalogMarkdown = (payload: QqMusicToolPayload): string => {
 	const data = payload.data as {
 		total: number;
@@ -277,7 +263,7 @@ export const createQqMusicMcpHandlers = (services: QqMusicMcpServices = defaultM
 	getAuthStatus: async (input: CommonInput): Promise<CallToolResult> => {
 		const responseFormat = getResponseFormat(input);
 		const userInfo = getUserInfo();
-		const keys = cookieKeys(userInfo.cookie);
+		const keys = getCookieKeys(userInfo.cookie);
 		const data = {
 			authenticated: Boolean(userInfo.cookie && (userInfo.uin || userInfo.loginUin)),
 			uin: userInfo.uin || userInfo.loginUin || '',
@@ -431,8 +417,8 @@ export const registerQqMusicMcpTools = (
 		{
 			title: 'QQ Music Config Status',
 			description: 'Return local QQ Music API config paths. Does not read or expose credential values.',
-			inputSchema: { response_format: responseFormatSchema },
-			outputSchema: mcpOutputSchema,
+			inputSchema: { response_format: responseFormatField },
+			outputSchema: mcpOutputShape,
 			annotations: readOnlyLocal,
 		},
 		handlers.getConfigStatus,
@@ -443,8 +429,8 @@ export const registerQqMusicMcpTools = (
 		{
 			title: 'QQ Music Auth Status',
 			description: 'Return redacted login status and cookie key names. Never returns full cookie values.',
-			inputSchema: { response_format: responseFormatSchema },
-			outputSchema: mcpOutputSchema,
+			inputSchema: { response_format: responseFormatField },
+			outputSchema: mcpOutputShape,
 			annotations: readOnlyLocal,
 		},
 		handlers.getAuthStatus,
@@ -459,9 +445,9 @@ export const registerQqMusicMcpTools = (
 				category: z.string().min(1).max(40).optional().describe("Optional category such as 'search', 'music', or 'playlist'."),
 				limit: z.number().int().min(1).max(100).default(20).describe('Maximum APIs to return.'),
 				offset: z.number().int().min(0).default(0).describe('Number of APIs to skip.'),
-				response_format: responseFormatSchema,
+				response_format: responseFormatField,
 			},
-			outputSchema: mcpOutputSchema,
+			outputSchema: mcpOutputShape,
 			annotations: readOnlyLocal,
 		},
 		handlers.listApis,
@@ -472,8 +458,8 @@ export const registerQqMusicMcpTools = (
 		{
 			title: 'Get QQ Music Hot Keys',
 			description: 'Fetch public QQ Music search hot keys from the upstream service.',
-			inputSchema: { response_format: responseFormatSchema },
-			outputSchema: mcpOutputSchema,
+			inputSchema: { response_format: responseFormatField },
+			outputSchema: mcpOutputShape,
 			annotations: readOnlyExternal,
 		},
 		handlers.getHotKeys,
@@ -492,9 +478,9 @@ export const registerQqMusicMcpTools = (
 					.enum(['song', 'album', 'mv', 'singer', 'smartbox'])
 					.default('song')
 					.describe('QQ Music search scope.'),
-				response_format: responseFormatSchema,
+				response_format: responseFormatField,
 			},
-			outputSchema: mcpOutputSchema,
+			outputSchema: mcpOutputShape,
 			annotations: readOnlyExternal,
 		},
 		handlers.searchSongs,
@@ -505,8 +491,8 @@ export const registerQqMusicMcpTools = (
 		{
 			title: 'Get QQ Music Top Lists',
 			description: 'Fetch public QQ Music ranking list metadata.',
-			inputSchema: { response_format: responseFormatSchema },
-			outputSchema: mcpOutputSchema,
+			inputSchema: { response_format: responseFormatField },
+			outputSchema: mcpOutputShape,
 			annotations: readOnlyExternal,
 		},
 		handlers.getTopLists,
@@ -519,9 +505,9 @@ export const registerQqMusicMcpTools = (
 			description: 'Fetch public QQ Music playlist details by disstid.',
 			inputSchema: {
 				disstid: z.string().min(1).max(80).describe('QQ Music playlist disstid.'),
-				response_format: responseFormatSchema,
+				response_format: responseFormatField,
 			},
-			outputSchema: mcpOutputSchema,
+			outputSchema: mcpOutputShape,
 			annotations: readOnlyExternal,
 		},
 		handlers.getPlaylistDetail,
@@ -534,9 +520,9 @@ export const registerQqMusicMcpTools = (
 			description: 'Fetch public QQ Music album information by albummid.',
 			inputSchema: {
 				albummid: z.string().min(1).max(80).describe('QQ Music album MID.'),
-				response_format: responseFormatSchema,
+				response_format: responseFormatField,
 			},
-			outputSchema: mcpOutputSchema,
+			outputSchema: mcpOutputShape,
 			annotations: readOnlyExternal,
 		},
 		handlers.getAlbumInfo,

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,0 +1,533 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { getConfigDir, resolveConfigPath } from '../config/config-path';
+import { getUserInfo } from '../config/user-info-store';
+import { apiMetadata } from '../routes/api-metadata';
+import {
+	getAlbumInfo,
+	getHotKey,
+	getSearchByKey,
+	getTopLists,
+	songListDetail,
+} from '../services';
+import type { ApiResponse } from '../types/api';
+
+const CHARACTER_LIMIT = 24_000;
+
+const responseFormatSchema = z
+	.enum(['markdown', 'json'])
+	.default('markdown')
+	.describe("Response format. Use 'markdown' for readable summaries or 'json' for structured output.");
+
+const mcpOutputSchema = {
+	ok: z.boolean(),
+	tool: z.string(),
+	status: z.number().optional(),
+	data: z.unknown().optional(),
+	error: z
+		.object({
+			code: z.string(),
+			message: z.string(),
+		})
+		.optional(),
+	metadata: z.record(z.string(), z.unknown()).optional(),
+};
+
+type ResponseFormat = 'markdown' | 'json';
+
+interface CommonInput {
+	response_format?: ResponseFormat;
+}
+
+interface ApiCatalogInput extends CommonInput {
+	category?: string;
+	limit?: number;
+	offset?: number;
+}
+
+interface SearchSongsInput extends CommonInput {
+	keyword: string;
+	page?: number;
+	limit?: number;
+	remoteplace?: 'song' | 'album' | 'mv' | 'singer' | 'smartbox';
+}
+
+interface PlaylistDetailInput extends CommonInput {
+	disstid: string;
+}
+
+interface AlbumInfoInput extends CommonInput {
+	albummid: string;
+}
+
+interface ServiceCallOptions {
+	method?: string;
+	params?: Record<string, unknown>;
+	option?: Record<string, unknown>;
+}
+
+type ServiceCall = (options: ServiceCallOptions) => Promise<ApiResponse>;
+
+export interface QqMusicMcpServices {
+	getAlbumInfo: ServiceCall;
+	getHotKey: ServiceCall;
+	getSearchByKey: ServiceCall;
+	getTopLists: ServiceCall;
+	songListDetail: ServiceCall;
+}
+
+export interface QqMusicToolPayload<TData = unknown> {
+	ok: boolean;
+	tool: string;
+	status?: number;
+	data?: TData;
+	error?: {
+		code: string;
+		message: string;
+	};
+	metadata?: Record<string, unknown>;
+}
+
+export const defaultMcpServices: QqMusicMcpServices = {
+	getAlbumInfo,
+	getHotKey,
+	getSearchByKey,
+	getTopLists,
+	songListDetail,
+};
+
+const getResponseFormat = (value: CommonInput): ResponseFormat => value.response_format || 'markdown';
+
+const truncate = (text: string, limit = CHARACTER_LIMIT): string => {
+	if (text.length <= limit) return text;
+	return `${text.slice(0, limit)}\n\n[Response truncated. Use json format or narrower parameters for more detail.]`;
+};
+
+const stringify = (value: unknown): string => {
+	try {
+		return JSON.stringify(value, null, 2);
+	} catch (error) {
+		return JSON.stringify(
+			{
+				error: 'SERIALIZE_FAILED',
+				message: error instanceof Error ? error.message : 'Unable to serialize response',
+			},
+			null,
+			2,
+		);
+	}
+};
+
+const jsonBlock = (title: string, value: unknown): string =>
+	[`# ${title}`, '', '```json', truncate(stringify(value), 12_000), '```'].join('\n');
+
+const createToolResult = <TData>(
+	payload: QqMusicToolPayload<TData>,
+	responseFormat: ResponseFormat,
+	markdown: string,
+): CallToolResult => {
+	const text = responseFormat === 'json' ? stringify(payload) : markdown;
+	return {
+		content: [{ type: 'text', text: truncate(text) }],
+		structuredContent: payload as unknown as Record<string, unknown>,
+		isError: !payload.ok,
+	};
+};
+
+const errorResult = (tool: string, error: unknown, responseFormat: ResponseFormat): CallToolResult => {
+	const message = error instanceof Error ? error.message : String(error);
+	const payload: QqMusicToolPayload = {
+		ok: false,
+		tool,
+		error: {
+			code: 'MCP_TOOL_FAILED',
+			message,
+		},
+	};
+
+	return createToolResult(payload, responseFormat, `Error: ${message}`);
+};
+
+const extractResponseData = (response: ApiResponse): unknown => {
+	if ('response' in response.body) return response.body.response;
+	if ('data' in response.body) return response.body.data;
+	return response.body;
+};
+
+const extractResponseError = (response: ApiResponse): unknown => {
+	if ('error' in response.body) return response.body.error;
+	return undefined;
+};
+
+const serviceResult = (
+	tool: string,
+	response: ApiResponse,
+	responseFormat: ResponseFormat,
+	title: string,
+): CallToolResult => {
+	const upstreamError = extractResponseError(response);
+	const ok = response.status >= 200 && response.status < 400 && upstreamError === undefined;
+	const data = extractResponseData(response);
+	const payload: QqMusicToolPayload = ok
+		? {
+				ok,
+				tool,
+				status: response.status,
+				data,
+			}
+		: {
+				ok,
+				tool,
+				status: response.status,
+				error: {
+					code: 'UPSTREAM_ERROR',
+					message: typeof upstreamError === 'string' ? upstreamError : stringify(upstreamError || data),
+				},
+				data,
+			};
+
+	return createToolResult(payload, responseFormat, jsonBlock(title, data));
+};
+
+const cookieKeys = (cookie: string | undefined): string[] => {
+	if (!cookie) return [];
+
+	return cookie
+		.split(';')
+		.map(item => item.trim())
+		.filter(Boolean)
+		.map(item => item.slice(0, item.indexOf('=')).trim())
+		.filter(Boolean);
+};
+
+const apiCatalogMarkdown = (payload: QqMusicToolPayload): string => {
+	const data = payload.data as {
+		total: number;
+		count: number;
+		offset: number;
+		limit: number;
+		items: Array<{
+			name: string;
+			category: string;
+			method: string;
+			path: string;
+			cookieRequired?: boolean;
+		}>;
+	};
+
+	const lines = [
+		'# QQ Music API Catalog',
+		'',
+		`Showing ${data.count} of ${data.total} APIs from offset ${data.offset}.`,
+		'',
+		'| Name | Category | Method | Path | Auth |',
+		'| --- | --- | --- | --- | --- |',
+	];
+
+	data.items.forEach(item => {
+		lines.push(
+			`| ${item.name} | ${item.category} | ${item.method} | ${item.path} | ${
+				item.cookieRequired ? 'cookie' : 'public'
+			} |`,
+		);
+	});
+
+	return lines.join('\n');
+};
+
+export const createQqMusicMcpHandlers = (services: QqMusicMcpServices = defaultMcpServices) => ({
+	getConfigStatus: async (input: CommonInput): Promise<CallToolResult> => {
+		const responseFormat = getResponseFormat(input);
+		const data = {
+			configDir: getConfigDir(),
+			serviceConfigPath: resolveConfigPath('service-config.json'),
+			userInfoPath: resolveConfigPath('user-info.json'),
+		};
+		const payload: QqMusicToolPayload = {
+			ok: true,
+			tool: 'qq_music_config_status',
+			data,
+		};
+
+		return createToolResult(
+			payload,
+			responseFormat,
+			[
+				'# QQ Music API Config',
+				'',
+				`- Config directory: ${data.configDir}`,
+				`- Service config: ${data.serviceConfigPath}`,
+				`- User info: ${data.userInfoPath}`,
+			].join('\n'),
+		);
+	},
+
+	getAuthStatus: async (input: CommonInput): Promise<CallToolResult> => {
+		const responseFormat = getResponseFormat(input);
+		const userInfo = getUserInfo();
+		const keys = cookieKeys(userInfo.cookie);
+		const data = {
+			authenticated: Boolean(userInfo.cookie && (userInfo.uin || userInfo.loginUin)),
+			uin: userInfo.uin || userInfo.loginUin || '',
+			hasCookie: Boolean(userInfo.cookie),
+			cookieKeys: keys,
+			cookieCount: keys.length,
+		};
+		const payload: QqMusicToolPayload = {
+			ok: true,
+			tool: 'qq_music_auth_status',
+			data,
+			metadata: {
+				redacted: true,
+			},
+		};
+
+		return createToolResult(
+			payload,
+			responseFormat,
+			[
+				'# QQ Music Auth Status',
+				'',
+				`- Authenticated: ${data.authenticated ? 'yes' : 'no'}`,
+				`- UIN: ${data.uin || 'missing'}`,
+				`- Cookie: ${data.hasCookie ? 'present' : 'missing'}`,
+				`- Cookie keys: ${data.cookieKeys.length ? data.cookieKeys.join(', ') : 'none'}`,
+				'',
+				'Cookie values are never returned by this MCP tool.',
+			].join('\n'),
+		);
+	},
+
+	listApis: async (input: ApiCatalogInput): Promise<CallToolResult> => {
+		const responseFormat = getResponseFormat(input);
+		const limit = Math.min(Math.max(input.limit || 20, 1), 100);
+		const offset = Math.max(input.offset || 0, 0);
+		const category = input.category?.trim();
+		const filtered = category ? apiMetadata.filter(item => item.category === category) : apiMetadata;
+		const items = filtered.slice(offset, offset + limit);
+		const data = {
+			total: filtered.length,
+			count: items.length,
+			offset,
+			limit,
+			hasMore: offset + items.length < filtered.length,
+			nextOffset: offset + items.length < filtered.length ? offset + items.length : undefined,
+			items,
+		};
+		const payload: QqMusicToolPayload = {
+			ok: true,
+			tool: 'qq_music_list_apis',
+			data,
+		};
+
+		return createToolResult(payload, responseFormat, apiCatalogMarkdown(payload));
+	},
+
+	getHotKeys: async (input: CommonInput): Promise<CallToolResult> => {
+		const responseFormat = getResponseFormat(input);
+		try {
+			const response = await services.getHotKey({ method: 'get', params: {}, option: {} });
+			return serviceResult('qq_music_get_hot_keys', response, responseFormat, 'QQ Music Hot Keys');
+		} catch (error) {
+			return errorResult('qq_music_get_hot_keys', error, responseFormat);
+		}
+	},
+
+	searchSongs: async (input: SearchSongsInput): Promise<CallToolResult> => {
+		const responseFormat = getResponseFormat(input);
+		try {
+			const response = await services.getSearchByKey({
+				method: 'get',
+				params: {
+					w: input.keyword,
+					n: Math.min(Math.max(input.limit || 10, 1), 50),
+					p: Math.max(input.page || 1, 1),
+					catZhida: 1,
+					remoteplace: `txt.yqq.${input.remoteplace || 'song'}`,
+				},
+				option: {},
+			});
+			return serviceResult('qq_music_search_songs', response, responseFormat, 'QQ Music Search Songs');
+		} catch (error) {
+			return errorResult('qq_music_search_songs', error, responseFormat);
+		}
+	},
+
+	getTopLists: async (input: CommonInput): Promise<CallToolResult> => {
+		const responseFormat = getResponseFormat(input);
+		try {
+			const response = await services.getTopLists({ method: 'get', params: {}, option: {} });
+			return serviceResult('qq_music_get_top_lists', response, responseFormat, 'QQ Music Top Lists');
+		} catch (error) {
+			return errorResult('qq_music_get_top_lists', error, responseFormat);
+		}
+	},
+
+	getPlaylistDetail: async (input: PlaylistDetailInput): Promise<CallToolResult> => {
+		const responseFormat = getResponseFormat(input);
+		try {
+			const response = await services.songListDetail({
+				method: 'get',
+				params: {
+					disstid: input.disstid,
+				},
+				option: {},
+			});
+			return serviceResult('qq_music_get_playlist_detail', response, responseFormat, 'QQ Music Playlist Detail');
+		} catch (error) {
+			return errorResult('qq_music_get_playlist_detail', error, responseFormat);
+		}
+	},
+
+	getAlbumInfo: async (input: AlbumInfoInput): Promise<CallToolResult> => {
+		const responseFormat = getResponseFormat(input);
+		try {
+			const response = await services.getAlbumInfo({
+				method: 'get',
+				params: {
+					albummid: input.albummid,
+				},
+				option: {},
+			});
+			return serviceResult('qq_music_get_album_info', response, responseFormat, 'QQ Music Album Info');
+		} catch (error) {
+			return errorResult('qq_music_get_album_info', error, responseFormat);
+		}
+	},
+});
+
+export const registerQqMusicMcpTools = (
+	server: McpServer,
+	services: QqMusicMcpServices = defaultMcpServices,
+): void => {
+	const handlers = createQqMusicMcpHandlers(services);
+	const readOnlyLocal = {
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: false,
+	};
+	const readOnlyExternal = {
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+	};
+
+	server.registerTool(
+		'qq_music_config_status',
+		{
+			title: 'QQ Music Config Status',
+			description: 'Return local QQ Music API config paths. Does not read or expose credential values.',
+			inputSchema: { response_format: responseFormatSchema },
+			outputSchema: mcpOutputSchema,
+			annotations: readOnlyLocal,
+		},
+		handlers.getConfigStatus,
+	);
+
+	server.registerTool(
+		'qq_music_auth_status',
+		{
+			title: 'QQ Music Auth Status',
+			description: 'Return redacted login status and cookie key names. Never returns full cookie values.',
+			inputSchema: { response_format: responseFormatSchema },
+			outputSchema: mcpOutputSchema,
+			annotations: readOnlyLocal,
+		},
+		handlers.getAuthStatus,
+	);
+
+	server.registerTool(
+		'qq_music_list_apis',
+		{
+			title: 'List QQ Music APIs',
+			description: 'List the HTTP API catalog exposed by this package with optional category filtering and pagination.',
+			inputSchema: {
+				category: z.string().min(1).max(40).optional().describe("Optional category such as 'search', 'music', or 'playlist'."),
+				limit: z.number().int().min(1).max(100).default(20).describe('Maximum APIs to return.'),
+				offset: z.number().int().min(0).default(0).describe('Number of APIs to skip.'),
+				response_format: responseFormatSchema,
+			},
+			outputSchema: mcpOutputSchema,
+			annotations: readOnlyLocal,
+		},
+		handlers.listApis,
+	);
+
+	server.registerTool(
+		'qq_music_get_hot_keys',
+		{
+			title: 'Get QQ Music Hot Keys',
+			description: 'Fetch public QQ Music search hot keys from the upstream service.',
+			inputSchema: { response_format: responseFormatSchema },
+			outputSchema: mcpOutputSchema,
+			annotations: readOnlyExternal,
+		},
+		handlers.getHotKeys,
+	);
+
+	server.registerTool(
+		'qq_music_search_songs',
+		{
+			title: 'Search QQ Music Songs',
+			description: 'Search public QQ Music results by keyword. Does not require or expose cookies.',
+			inputSchema: {
+				keyword: z.string().min(1).max(100).describe('Search keyword, for example a song title or artist name.'),
+				page: z.number().int().min(1).default(1).describe('Result page number, starting from 1.'),
+				limit: z.number().int().min(1).max(50).default(10).describe('Maximum results per page.'),
+				remoteplace: z
+					.enum(['song', 'album', 'mv', 'singer', 'smartbox'])
+					.default('song')
+					.describe('QQ Music search scope.'),
+				response_format: responseFormatSchema,
+			},
+			outputSchema: mcpOutputSchema,
+			annotations: readOnlyExternal,
+		},
+		handlers.searchSongs,
+	);
+
+	server.registerTool(
+		'qq_music_get_top_lists',
+		{
+			title: 'Get QQ Music Top Lists',
+			description: 'Fetch public QQ Music ranking list metadata.',
+			inputSchema: { response_format: responseFormatSchema },
+			outputSchema: mcpOutputSchema,
+			annotations: readOnlyExternal,
+		},
+		handlers.getTopLists,
+	);
+
+	server.registerTool(
+		'qq_music_get_playlist_detail',
+		{
+			title: 'Get QQ Music Playlist Detail',
+			description: 'Fetch public QQ Music playlist details by disstid.',
+			inputSchema: {
+				disstid: z.string().min(1).max(80).describe('QQ Music playlist disstid.'),
+				response_format: responseFormatSchema,
+			},
+			outputSchema: mcpOutputSchema,
+			annotations: readOnlyExternal,
+		},
+		handlers.getPlaylistDetail,
+	);
+
+	server.registerTool(
+		'qq_music_get_album_info',
+		{
+			title: 'Get QQ Music Album Info',
+			description: 'Fetch public QQ Music album information by albummid.',
+			inputSchema: {
+				albummid: z.string().min(1).max(80).describe('QQ Music album MID.'),
+				response_format: responseFormatSchema,
+			},
+			outputSchema: mcpOutputSchema,
+			annotations: readOnlyExternal,
+		},
+		handlers.getAlbumInfo,
+	);
+};

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -14,6 +14,7 @@ import {
 import type { ApiResponse } from '../types/api';
 
 const CHARACTER_LIMIT = 24_000;
+const ERROR_MESSAGE_LIMIT = 2_000;
 
 const responseFormatSchema = z
 	.enum(['markdown', 'json'])
@@ -122,6 +123,11 @@ const stringify = (value: unknown): string => {
 const jsonBlock = (title: string, value: unknown): string =>
 	[`# ${title}`, '', '```json', truncate(stringify(value), 12_000), '```'].join('\n');
 
+const errorMessageText = (value: unknown): string => {
+	const text = typeof value === 'string' ? value : stringify(value);
+	return truncate(text, ERROR_MESSAGE_LIMIT);
+};
+
 const createToolResult = <TData>(
 	payload: QqMusicToolPayload<TData>,
 	responseFormat: ResponseFormat,
@@ -136,7 +142,7 @@ const createToolResult = <TData>(
 };
 
 const errorResult = (tool: string, error: unknown, responseFormat: ResponseFormat): CallToolResult => {
-	const message = error instanceof Error ? error.message : String(error);
+	const message = errorMessageText(error instanceof Error ? error.message : error);
 	const payload: QqMusicToolPayload = {
 		ok: false,
 		tool,
@@ -182,7 +188,7 @@ const serviceResult = (
 				status: response.status,
 				error: {
 					code: 'UPSTREAM_ERROR',
-					message: typeof upstreamError === 'string' ? upstreamError : stringify(upstreamError || data),
+					message: errorMessageText(upstreamError ?? data),
 				},
 				data,
 			};
@@ -197,8 +203,13 @@ const cookieKeys = (cookie: string | undefined): string[] => {
 		.split(';')
 		.map(item => item.trim())
 		.filter(Boolean)
-		.map(item => item.slice(0, item.indexOf('=')).trim())
-		.filter(Boolean);
+		.flatMap(item => {
+			const separatorIndex = item.indexOf('=');
+			if (separatorIndex <= 0) return [];
+
+			const key = item.slice(0, separatorIndex).trim();
+			return key ? [key] : [];
+		});
 };
 
 const apiCatalogMarkdown = (payload: QqMusicToolPayload): string => {

--- a/src/util/cookieResolver.ts
+++ b/src/util/cookieResolver.ts
@@ -42,6 +42,22 @@ export const extractCookieValue = (cookie: string | undefined, name: string): st
   return value || undefined;
 };
 
+export const getCookieKeys = (cookie: string | undefined): string[] => {
+  if (!cookie) return [];
+
+  return cookie
+    .split(';')
+    .map(item => item.trim())
+    .filter(Boolean)
+    .flatMap(item => {
+      const separatorIndex = item.indexOf('=');
+      if (separatorIndex <= 0) return [];
+
+      const key = item.slice(0, separatorIndex).trim();
+      return key ? [key] : [];
+    });
+};
+
 export const extractUinFromCookie = (cookie?: string): string | undefined => {
   return extractCookieValue(cookie, 'uin');
 };

--- a/tests/integration/package-entry.test.ts
+++ b/tests/integration/package-entry.test.ts
@@ -275,12 +275,27 @@ describe('Package Entry Compatibility', () => {
 				await client.connect(transport);
 				const tools = await client.listTools();
 				const toolNames = tools.tools.map(tool => tool.name);
+				const searchTool = tools.tools.find(tool => tool.name === 'qq_music_search_songs');
 
 				expect(toolNames).toEqual(expect.arrayContaining([
 					'qq_music_config_status',
 					'qq_music_list_apis',
 					'qq_music_search_songs',
 				]));
+				expect(searchTool?.inputSchema).toMatchObject({
+					type: 'object',
+					properties: {
+						keyword: expect.any(Object),
+						response_format: expect.any(Object),
+					},
+				});
+				expect(searchTool?.outputSchema).toMatchObject({
+					type: 'object',
+					properties: {
+						ok: expect.any(Object),
+						tool: expect.any(Object),
+					},
+				});
 
 				const result = await client.callTool({
 					name: 'qq_music_config_status',

--- a/tests/integration/package-entry.test.ts
+++ b/tests/integration/package-entry.test.ts
@@ -253,6 +253,9 @@ describe('Package Entry Compatibility', () => {
 	test(
 		'should expose MCP tools over stdio through the CLI',
 		async () => {
+			fs.mkdirSync(configDir, { recursive: true });
+			fs.writeFileSync(path.join(configDir, 'service-config.json'), '{ invalid json', 'utf-8');
+
 			const transport = new StdioClientTransport({
 				command: process.execPath,
 				args: [getPackageBinEntry(), 'mcp', 'start'],
@@ -353,7 +356,7 @@ describe('Package Entry Compatibility', () => {
 			path.join(configDir, 'user-info.json'),
 			JSON.stringify({
 				loginUin: 'o123456',
-				cookie: 'uin=o123456; qqmusic_key=secret-value',
+				cookie: 'uin=o123456; malformed; qqmusic_key=secret-value',
 			}),
 			'utf-8',
 		);

--- a/tests/integration/package-entry.test.ts
+++ b/tests/integration/package-entry.test.ts
@@ -2,6 +2,8 @@ import { exec, execFile } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -245,7 +247,58 @@ describe('Package Entry Compatibility', () => {
 
 		expect(stdout).toContain('qq-music-api config doctor');
 		expect(stdout).toContain('qq-music-api auth status');
+		expect(stdout).toContain('qq-music-api mcp start');
 	});
+
+	test(
+		'should expose MCP tools over stdio through the CLI',
+		async () => {
+			const transport = new StdioClientTransport({
+				command: process.execPath,
+				args: [getPackageBinEntry(), 'mcp', 'start'],
+				cwd: projectRoot,
+				env: {
+					...process.env,
+					QQ_MUSIC_API_CONFIG_DIR: configDir,
+				},
+				stderr: 'pipe',
+			});
+			const client = new Client({
+				name: 'qq-music-api-package-entry-test',
+				version: '1.0.0',
+			});
+
+			try {
+				await client.connect(transport);
+				const tools = await client.listTools();
+				const toolNames = tools.tools.map(tool => tool.name);
+
+				expect(toolNames).toEqual(expect.arrayContaining([
+					'qq_music_config_status',
+					'qq_music_list_apis',
+					'qq_music_search_songs',
+				]));
+
+				const result = await client.callTool({
+					name: 'qq_music_config_status',
+					arguments: { response_format: 'json' },
+				});
+
+				expect(result.structuredContent).toMatchObject({
+					ok: true,
+					tool: 'qq_music_config_status',
+					data: {
+						configDir,
+						serviceConfigPath: path.join(configDir, 'service-config.json'),
+						userInfoPath: path.join(configDir, 'user-info.json'),
+					},
+				});
+			} finally {
+				await client.close();
+			}
+		},
+		60_000,
+	);
 
 	test('should return config paths as JSON', async () => {
 		const { stdout } = await runNode([getPackageBinEntry(), 'config', 'path', '--json']);

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -1,0 +1,43 @@
+const runMcpServerMock = vi.fn();
+
+vi.mock('../../src/mcp/server', () => ({
+	runMcpServer: runMcpServerMock,
+}));
+
+describe('CLI', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		runMcpServerMock.mockReset();
+	});
+
+	test('keeps stdout redirected for the MCP server lifetime', async () => {
+		runMcpServerMock.mockResolvedValue(undefined);
+		const originalLog = console.log;
+		const originalInfo = console.info;
+		const originalWarn = console.warn;
+		const originalExitListeners = process.rawListeners('exit');
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+		const { runCli } = await import('../../src/cli');
+
+		await expect(runCli(['mcp', 'start'])).resolves.toBe(0);
+
+		console.log('after connect');
+		console.info('after connect info');
+		console.warn('after connect warn');
+
+		expect(errorSpy).toHaveBeenCalledWith('after connect');
+		expect(errorSpy).toHaveBeenCalledWith('after connect info');
+		expect(errorSpy).toHaveBeenCalledWith('after connect warn');
+
+		const addedExitListeners = process
+			.rawListeners('exit')
+			.filter(listener => !originalExitListeners.includes(listener));
+		expect(addedExitListeners).toHaveLength(1);
+
+		Reflect.apply(addedExitListeners[0], process, [0]);
+
+		expect(console.log).toBe(originalLog);
+		expect(console.info).toBe(originalInfo);
+		expect(console.warn).toBe(originalWarn);
+	});
+});

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -15,29 +15,60 @@ describe('CLI', () => {
 		const originalLog = console.log;
 		const originalInfo = console.info;
 		const originalWarn = console.warn;
+		const originalDebug = console.debug;
 		const originalExitListeners = process.rawListeners('exit');
 		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 		const { runCli } = await import('../../src/cli');
 
-		await expect(runCli(['mcp', 'start'])).resolves.toBe(0);
+		try {
+			await expect(runCli(['mcp', 'start'])).resolves.toBe(0);
 
-		console.log('after connect');
-		console.info('after connect info');
-		console.warn('after connect warn');
+			console.log('after connect');
+			console.info('after connect info');
+			console.warn('after connect warn');
+			console.debug('after connect debug');
 
-		expect(errorSpy).toHaveBeenCalledWith('after connect');
-		expect(errorSpy).toHaveBeenCalledWith('after connect info');
-		expect(errorSpy).toHaveBeenCalledWith('after connect warn');
+			expect(errorSpy).toHaveBeenCalledWith('after connect');
+			expect(errorSpy).toHaveBeenCalledWith('after connect info');
+			expect(errorSpy).toHaveBeenCalledWith('after connect warn');
+			expect(errorSpy).toHaveBeenCalledWith('after connect debug');
 
-		const addedExitListeners = process
-			.rawListeners('exit')
-			.filter(listener => !originalExitListeners.includes(listener));
-		expect(addedExitListeners).toHaveLength(1);
+			const addedExitListeners = process
+				.rawListeners('exit')
+				.filter(listener => !originalExitListeners.includes(listener));
+			expect(addedExitListeners).toHaveLength(1);
 
-		Reflect.apply(addedExitListeners[0], process, [0]);
+			Reflect.apply(addedExitListeners[0], process, [0]);
+
+			expect(console.log).toBe(originalLog);
+			expect(console.info).toBe(originalInfo);
+			expect(console.warn).toBe(originalWarn);
+			expect(console.debug).toBe(originalDebug);
+		} finally {
+			console.log = originalLog;
+			console.info = originalInfo;
+			console.warn = originalWarn;
+			console.debug = originalDebug;
+		}
+	});
+
+	test('restores console and exit listeners when runMcpServer rejects', async () => {
+		runMcpServerMock.mockRejectedValue(new Error('boom'));
+		const originalLog = console.log;
+		const originalInfo = console.info;
+		const originalWarn = console.warn;
+		const originalDebug = console.debug;
+		const originalExitListeners = process.rawListeners('exit');
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+		const { runCli } = await import('../../src/cli');
+
+		await expect(runCli(['mcp', 'start'])).resolves.toBe(1);
 
 		expect(console.log).toBe(originalLog);
 		expect(console.info).toBe(originalInfo);
 		expect(console.warn).toBe(originalWarn);
+		expect(console.debug).toBe(originalDebug);
+		expect(process.rawListeners('exit')).toEqual(originalExitListeners);
+		expect(errorSpy).toHaveBeenCalledWith('Error: boom');
 	});
 });

--- a/tests/unit/mcp/tools.test.ts
+++ b/tests/unit/mcp/tools.test.ts
@@ -54,7 +54,7 @@ describe('MCP tool handlers', () => {
 		setUserInfo({
 			loginUin: 'o123456',
 			uin: 'o123456',
-			cookie: 'uin=o123456; qqmusic_key=secret-value',
+			cookie: 'uin=o123456; malformed; qqmusic_key=secret-value',
 			cookieList: [],
 			cookieObject: {},
 			refreshData: () => ({}),
@@ -69,6 +69,7 @@ describe('MCP tool handlers', () => {
 		expect(text).toContain('qqmusic_key');
 		expect(text).not.toContain('secret-value');
 		expect(payload.metadata).toEqual({ redacted: true });
+		expect((payload.data as { cookieKeys: string[] }).cookieKeys).toEqual(['uin', 'qqmusic_key']);
 	});
 
 	test('searches songs through the service layer with normalized params', async () => {
@@ -119,5 +120,28 @@ describe('MCP tool handlers', () => {
 				message: 'network down',
 			},
 		});
+	});
+
+	test('bounds upstream error messages in structured content', async () => {
+		const longDetail = 'x'.repeat(5_000);
+		const services = createServices({
+			getTopLists: vi.fn().mockResolvedValue({
+				status: 502,
+				body: {
+					error: {
+						detail: longDetail,
+					},
+				},
+			}),
+		});
+		const handlers = createQqMusicMcpHandlers(services);
+
+		const result = await handlers.getTopLists({ response_format: 'json' });
+		const payload = payloadOf(result);
+
+		expect(result.isError).toBe(true);
+		expect(payload.error?.code).toBe('UPSTREAM_ERROR');
+		expect(payload.error?.message.length).toBeLessThan(2_200);
+		expect(payload.error?.message).toContain('Response truncated');
 	});
 });

--- a/tests/unit/mcp/tools.test.ts
+++ b/tests/unit/mcp/tools.test.ts
@@ -1,0 +1,123 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { setUserInfo } from '../../../src/config/user-info-store';
+import {
+	createQqMusicMcpHandlers,
+	type QqMusicMcpServices,
+	type QqMusicToolPayload,
+} from '../../../src/mcp/tools';
+
+const okResponse = (data: unknown) => ({
+	status: 200,
+	body: {
+		response: data,
+	},
+});
+
+const createServices = (overrides: Partial<QqMusicMcpServices> = {}): QqMusicMcpServices => ({
+	getAlbumInfo: vi.fn().mockResolvedValue(okResponse({ album: 'mock' })),
+	getHotKey: vi.fn().mockResolvedValue(okResponse({ hotkeys: ['test'] })),
+	getSearchByKey: vi.fn().mockResolvedValue(okResponse({ songs: [{ songmid: 'abc', name: 'Mock Song' }] })),
+	getTopLists: vi.fn().mockResolvedValue(okResponse({ topLists: [] })),
+	songListDetail: vi.fn().mockResolvedValue(okResponse({ dissid: '123' })),
+	...overrides,
+});
+
+const payloadOf = (result: CallToolResult): QqMusicToolPayload => result.structuredContent as QqMusicToolPayload;
+
+describe('MCP tool handlers', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+		setUserInfo({
+			loginUin: '',
+			uin: '',
+			cookie: '',
+			cookieList: [],
+			cookieObject: {},
+			refreshData: () => ({}),
+		});
+	});
+
+	test('lists API metadata with pagination', async () => {
+		const handlers = createQqMusicMcpHandlers(createServices());
+		const result = await handlers.listApis({ category: 'search', limit: 2, offset: 0, response_format: 'json' });
+		const payload = payloadOf(result);
+		const data = payload.data as { count: number; total: number; hasMore: boolean };
+
+		expect(payload.ok).toBe(true);
+		expect(payload.tool).toBe('qq_music_list_apis');
+		expect(data.count).toBe(2);
+		expect(data.total).toBeGreaterThanOrEqual(2);
+		expect(data.hasMore).toBe(true);
+	});
+
+	test('reports auth status without leaking cookie values', async () => {
+		setUserInfo({
+			loginUin: 'o123456',
+			uin: 'o123456',
+			cookie: 'uin=o123456; qqmusic_key=secret-value',
+			cookieList: [],
+			cookieObject: {},
+			refreshData: () => ({}),
+		});
+
+		const handlers = createQqMusicMcpHandlers(createServices());
+		const result = await handlers.getAuthStatus({ response_format: 'json' });
+		const payload = payloadOf(result);
+		const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+
+		expect(payload.ok).toBe(true);
+		expect(text).toContain('qqmusic_key');
+		expect(text).not.toContain('secret-value');
+		expect(payload.metadata).toEqual({ redacted: true });
+	});
+
+	test('searches songs through the service layer with normalized params', async () => {
+		const services = createServices();
+		const handlers = createQqMusicMcpHandlers(services);
+
+		const result = await handlers.searchSongs({
+			keyword: 'jay',
+			page: 2,
+			limit: 5,
+			remoteplace: 'song',
+			response_format: 'json',
+		});
+
+		expect(services.getSearchByKey).toHaveBeenCalledWith({
+			method: 'get',
+			params: {
+				w: 'jay',
+				n: 5,
+				p: 2,
+				catZhida: 1,
+				remoteplace: 'txt.yqq.song',
+			},
+			option: {},
+		});
+		expect(payloadOf(result)).toMatchObject({
+			ok: true,
+			tool: 'qq_music_search_songs',
+			status: 200,
+		});
+	});
+
+	test('returns MCP tool errors without throwing protocol errors', async () => {
+		const services = createServices({
+			getTopLists: vi.fn().mockRejectedValue(new Error('network down')),
+		});
+		const handlers = createQqMusicMcpHandlers(services);
+
+		const result = await handlers.getTopLists({ response_format: 'json' });
+		const payload = payloadOf(result);
+
+		expect(result.isError).toBe(true);
+		expect(payload).toMatchObject({
+			ok: false,
+			tool: 'qq_music_get_top_lists',
+			error: {
+				code: 'MCP_TOOL_FAILED',
+				message: 'network down',
+			},
+		});
+	});
+});

--- a/tests/unit/util/cookieResolver.test.ts
+++ b/tests/unit/util/cookieResolver.test.ts
@@ -2,6 +2,7 @@ import type { UserInfo } from '../../../src/types';
 import {
   extractCookieValue,
   extractUinFromCookie,
+  getCookieKeys,
   resolveRequestCookie,
 } from '../../../src/util/cookieResolver';
 
@@ -44,6 +45,13 @@ describe('util/cookieResolver cookie value parsing', () => {
   test('should trim values and ignore empty matches', () => {
     expect(extractCookieValue('qqmusic_key=  value  ', 'qqmusic_key')).toBe('value');
     expect(extractCookieValue('qqmusic_key=; uin=o123456', 'qqmusic_key')).toBeUndefined();
+  });
+
+  test('should list cookie keys while skipping malformed segments', () => {
+    expect(getCookieKeys('uin=o123456; malformed; =empty; qqmusic_key=secret=value')).toEqual([
+      'uin',
+      'qqmusic_key',
+    ]);
   });
 
   test('should reuse cookie value parsing for uin extraction', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,14 @@ import { resolve } from 'node:path';
 import { oxcTransform } from './plugins/vite-plugin-oxc-transform';
 import type { Plugin } from 'vite';
 
+const externalPackages = [
+	'koa',
+	'@koa/router',
+	'axios',
+	'@modelcontextprotocol/sdk',
+	'zod',
+];
+
 function nodeBinShebang(): Plugin {
 	const binEntryIds = new Set([
 		normalizePath(resolve(__dirname, 'src/app.ts')),
@@ -59,11 +67,7 @@ export default defineConfig({
 		emptyOutDir: true,
 		copyPublicDir: false,
 		rollupOptions: {
-			external: [
-				'koa',
-				'@koa/router',
-				'axios',
-			],
+			external: id => externalPackages.some(pkg => id === pkg || id.startsWith(`${pkg}/`)),
 		},
 	},
 	resolve: {


### PR DESCRIPTION
## Summary
- add a stdio MCP server entry via `qq-music-api mcp start`
- register read-only QQ Music MCP tools for config/auth summary, API catalog, hot keys, search, rankings, playlist detail, and album info
- document MCP usage and add unit/integration coverage, including an SDK client stdio smoke test

## Validation
- npm run build
- npx vitest run tests/unit/mcp/tools.test.ts tests/integration/package-entry.test.ts
- npm run lint
- npm run test
- npm run docs:build

## Summary by Sourcery

在 CLI 中新增一个基于 stdio 的 MCP 服务器入口，用于暴露只读的 QQ 音乐工具及其支撑基础设施。

New Features:
- 新增一个通过 `qq-music-api mcp start` 命令及相应 npm 脚本接入 CLI 的 stdio MCP 服务器。
- 为 QQ 音乐配置/认证状态、API 目录列表、搜索、排行榜、歌单详情和专辑信息注册一组只读 MCP 工具，并提供一个 API 目录资源。

Enhancements:
- 优化 CLI 和 MCP 文档，描述当前功能、使用模式以及工具边界。
- 改进 CLI 对 cookie 键值的解析，安全处理格式不正确的 cookie 片段。
- 在 MCP 服务器运行期间，将 CLI 控制台输出重定向到 stderr，以保留 stdout 用于协议数据流。
- 扩展 Vite 的 Rollup externals 配置，将 MCP SDK 和校验库（包括其子路径）作为外部依赖处理。

Build:
- 更新 Vite 构建配置，将 `@modelcontextprotocol/sdk`、`zod` 以及相关子路径与现有服务器依赖一起外部化处理。

Documentation:
- 在 README 和 MCP/CLI 指南中记录 MCP 服务器的用法、可用工具以及 CLI 集成方式，并包含示例客户端配置。
- 将 MCP/CLI 指南从偏未来规划的设计笔记重构为“当前能力 + 未来扩展方向”的结构。

Tests:
- 为 MCP 工具处理程序新增单元测试，覆盖正常路径、错误整形以及认证信息脱敏保证。
- 为 CLI 的 MCP 行为新增单元测试，并添加一个集成测试，将 MCP SDK 客户端连接到 CLI 的 stdio 服务器并验证关键工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a stdio-based MCP server entry to the CLI that exposes read-only QQ Music tools and supporting infrastructure.

New Features:
- Introduce a stdio MCP server wired into the CLI via the `qq-music-api mcp start` command and corresponding npm scripts.
- Register a set of read-only MCP tools for QQ Music config/auth status, API catalog listing, search, rankings, playlist detail, and album info, plus an API catalog resource.

Enhancements:
- Refine CLI and MCP documentation to describe current capabilities, usage patterns, and tool boundaries.
- Improve CLI cookie key parsing to safely handle malformed cookie segments.
- Redirect CLI console output to stderr while the MCP server is running to keep stdout reserved for the protocol stream.
- Extend Vite Rollup externals to treat the MCP SDK and validation library (including subpaths) as external dependencies.

Build:
- Update Vite build configuration to externalize `@modelcontextprotocol/sdk`, `zod`, and related subpaths alongside existing server dependencies.

Documentation:
- Document MCP server usage, available tools, and CLI integration in the README and MCP/CLI guide, including example client configuration.
- Reframe the MCP/CLI guide from future-oriented design notes to current capabilities plus future extension directions.

Tests:
- Add unit tests for MCP tool handlers covering happy paths, error shaping, and auth redaction guarantees.
- Add unit tests for CLI MCP behavior and an integration test that connects an MCP SDK client to the CLI stdio server and exercises key tools.

</details>

新功能：
- 引入一个基于 stdio 的 MCP 服务器，将 QQ 音乐 API 功能暴露为 MCP 工具。
- 添加 `qq-music-api mcp start` CLI 命令和 npm 脚本，以便在开发环境和构建后的环境中运行 MCP 服务器。
- 注册只读 MCP 工具，用于配置/认证状态、API 目录列表、搜索、排行榜、歌单详情和专辑信息，并提供一个 API 目录资源。

增强：
- 优化 MCP 和 CLI 指南文档，描述当前能力、使用方式以及工具边界。
- 扩展打包器的 externals 配置，将 MCP SDK 和校验库纳入 externals，以保持构建产物精简。

构建：
- 更新 Vite Rollup externals，将 MCP SDK 及其相关子路径以及 `zod` 视为外部依赖。

文档：
- 在 README 和 MCP/CLI 指南中记录 MCP 服务器的使用方式、可用工具和 CLI 集成方式，包括示例客户端配置。

测试：
- 为 MCP 工具处理程序添加单元测试，并添加一个集成测试，通过包的 CLI 入口以 stdio 方式连接到 MCP 服务器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 CLI 中新增一个基于 stdio 的 MCP 服务器入口，用于暴露只读的 QQ 音乐工具及其支撑基础设施。

New Features:
- 新增一个通过 `qq-music-api mcp start` 命令及相应 npm 脚本接入 CLI 的 stdio MCP 服务器。
- 为 QQ 音乐配置/认证状态、API 目录列表、搜索、排行榜、歌单详情和专辑信息注册一组只读 MCP 工具，并提供一个 API 目录资源。

Enhancements:
- 优化 CLI 和 MCP 文档，描述当前功能、使用模式以及工具边界。
- 改进 CLI 对 cookie 键值的解析，安全处理格式不正确的 cookie 片段。
- 在 MCP 服务器运行期间，将 CLI 控制台输出重定向到 stderr，以保留 stdout 用于协议数据流。
- 扩展 Vite 的 Rollup externals 配置，将 MCP SDK 和校验库（包括其子路径）作为外部依赖处理。

Build:
- 更新 Vite 构建配置，将 `@modelcontextprotocol/sdk`、`zod` 以及相关子路径与现有服务器依赖一起外部化处理。

Documentation:
- 在 README 和 MCP/CLI 指南中记录 MCP 服务器的用法、可用工具以及 CLI 集成方式，并包含示例客户端配置。
- 将 MCP/CLI 指南从偏未来规划的设计笔记重构为“当前能力 + 未来扩展方向”的结构。

Tests:
- 为 MCP 工具处理程序新增单元测试，覆盖正常路径、错误整形以及认证信息脱敏保证。
- 为 CLI 的 MCP 行为新增单元测试，并添加一个集成测试，将 MCP SDK 客户端连接到 CLI 的 stdio 服务器并验证关键工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a stdio-based MCP server entry to the CLI that exposes read-only QQ Music tools and supporting infrastructure.

New Features:
- Introduce a stdio MCP server wired into the CLI via the `qq-music-api mcp start` command and corresponding npm scripts.
- Register a set of read-only MCP tools for QQ Music config/auth status, API catalog listing, search, rankings, playlist detail, and album info, plus an API catalog resource.

Enhancements:
- Refine CLI and MCP documentation to describe current capabilities, usage patterns, and tool boundaries.
- Improve CLI cookie key parsing to safely handle malformed cookie segments.
- Redirect CLI console output to stderr while the MCP server is running to keep stdout reserved for the protocol stream.
- Extend Vite Rollup externals to treat the MCP SDK and validation library (including subpaths) as external dependencies.

Build:
- Update Vite build configuration to externalize `@modelcontextprotocol/sdk`, `zod`, and related subpaths alongside existing server dependencies.

Documentation:
- Document MCP server usage, available tools, and CLI integration in the README and MCP/CLI guide, including example client configuration.
- Reframe the MCP/CLI guide from future-oriented design notes to current capabilities plus future extension directions.

Tests:
- Add unit tests for MCP tool handlers covering happy paths, error shaping, and auth redaction guarantees.
- Add unit tests for CLI MCP behavior and an integration test that connects an MCP SDK client to the CLI stdio server and exercises key tools.

</details>

</details>