### PR TITLE
feat: 暴露服务和 SDK 函数入口点

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ spawn('node', [qqMusicPath], {
 });
 ```
 
+也可以直接在 Node.js 项目中函数式调用，不需要单独启动 HTTP 服务：
+
+```javascript
+import { search, getMusicPlay, getLyric } from '@sansenjian/qq-music-api/sdk';
+
+const searchResult = await search({ key: '周杰伦', limit: 20 });
+const playResult = await getMusicPlay({
+	songmid: '003rJSwm3TechU',
+	quality: '320',
+	cookie: 'uin=o123456; qqmusic_key=your-key',
+});
+const lyricResult = await getLyric({
+	songmid: '003rJSwm3TechU',
+	isFormat: true,
+});
+
+console.log(searchResult, playResult, lyricResult);
+```
+
 ## 项目启动
 
 ```bash

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -35,6 +35,7 @@ export default defineConfig({
           { text: '使用指南', link: '/guide/' },
           { text: '安装指南', link: '/guide/installation' },
           { text: '快速开始', link: '/guide/quickstart' },
+          { text: 'SDK 函数式调用', link: '/guide/sdk-usage' },
           { text: '快速使用指南', link: '/QUICK_START' },
           { text: '降级服务示例', link: '/DEGRADE_EXAMPLES' },
         ],
@@ -153,4 +154,3 @@ export default defineConfig({
     },
   },
 })
-

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -17,6 +17,8 @@ npm run dev
 
 当前项目以 `GET` 接口为主，同时提供少量 `POST` 接口用于批量查询和扫码登录状态轮询。
 
+如果你的项目只需要在 Node.js 后端直接调用 QQ 音乐能力，也可以使用 [SDK 函数式调用](/guide/sdk-usage)，不需要单独启动 HTTP 服务。
+
 ### 常见 GET 请求示例
 
 ```bash

--- a/docs/guide/sdk-usage.md
+++ b/docs/guide/sdk-usage.md
@@ -1,0 +1,85 @@
+# SDK 函数式调用
+
+除了启动 Koa HTTP 服务，`@sansenjian/qq-music-api` 也提供 Node.js 函数式调用入口，适合在已有后端项目中直接复用 QQ 音乐能力。
+
+## 安装
+
+```bash
+npm install @sansenjian/qq-music-api
+```
+
+## 推荐入口
+
+```ts
+import { search, getMusicPlay, getLyric } from '@sansenjian/qq-music-api/sdk'
+
+const searchResult = await search({
+  key: '周杰伦',
+  limit: 20,
+  page: 1
+})
+
+const playResult = await getMusicPlay({
+  songmid: '003rJSwm3TechU',
+  quality: '320',
+  cookie: 'uin=o123456; qqmusic_key=your-key'
+})
+
+const lyricResult = await getLyric({
+  songmid: '003rJSwm3TechU',
+  isFormat: true,
+  cookie: 'uin=o123456; qqmusic_key=your-key'
+})
+
+console.log(searchResult, playResult, lyricResult)
+```
+
+## 登录二维码
+
+```ts
+import { getQQLoginQr, checkQQLoginQr } from '@sansenjian/qq-music-api/sdk'
+
+const qr = await getQQLoginQr()
+const result = await checkQQLoginQr({
+  ptqrtoken: 123456,
+  qrsig: 'qrsig-from-qr-response'
+})
+```
+
+`checkQQLoginQr` 登录成功后会返回 session 信息，调用方可以自行保存 `session.cookie`，并在播放、歌词等依赖登录态的接口中通过 `cookie` 参数传入。
+
+## 底层服务入口
+
+如果需要完全复用原始 service 参数结构，可以直接导入 `services`：
+
+```ts
+import { getSearchByKey, getMusicPlay } from '@sansenjian/qq-music-api/services'
+
+await getSearchByKey({
+  method: 'get',
+  params: {
+    w: '周杰伦',
+    n: 20,
+    p: 1
+  }
+})
+
+await getMusicPlay({
+  method: 'get',
+  params: {
+    songmid: '003rJSwm3TechU',
+    quality: '320'
+  },
+  option: {
+    headers: {
+      Cookie: 'uin=o123456; qqmusic_key=your-key'
+    }
+  }
+})
+```
+
+## 与 HTTP 服务的关系
+
+- `@sansenjian/qq-music-api` 默认入口仍然导出 Koa app，现有部署方式不变。
+- `@sansenjian/qq-music-api/sdk` 不启动 HTTP 服务。
+- `@sansenjian/qq-music-api/services` 面向需要底层参数控制的调用方，返回结构与现有 service 层保持一致。

--- a/package.json
+++ b/package.json
@@ -23,6 +23,26 @@
 				"types": "./dist/index.d.cts",
 				"default": "./dist/index.cjs"
 			}
+		},
+		"./services": {
+			"import": {
+				"types": "./dist/services.d.mts",
+				"default": "./dist/services.js"
+			},
+			"require": {
+				"types": "./dist/services.d.cts",
+				"default": "./dist/services.cjs"
+			}
+		},
+		"./sdk": {
+			"import": {
+				"types": "./dist/sdk.d.mts",
+				"default": "./dist/sdk.js"
+			},
+			"require": {
+				"types": "./dist/sdk.d.cts",
+				"default": "./dist/sdk.cjs"
+			}
 		}
 	},
 	"bin": {
@@ -41,6 +61,16 @@
 		"dist/index.cjs",
 		"dist/index.d.cts",
 		"dist/index.d.mts",
+		"dist/sdk.js",
+		"dist/sdk.cjs",
+		"dist/sdk.d.cts",
+		"dist/sdk.d.mts",
+		"dist/sdk.d.ts",
+		"dist/services.js",
+		"dist/services.cjs",
+		"dist/services.d.cts",
+		"dist/services.d.mts",
+		"dist/services.d.ts",
 		"dist/app.d.ts",
 		"dist/index.d.ts",
 		"dist/config",

--- a/scripts/fix-cjs-declarations.js
+++ b/scripts/fix-cjs-declarations.js
@@ -1,6 +1,36 @@
-import { writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 
 const appDeclaration = "import type Koa = require('koa');\ndeclare const app: Koa;\n";
+const readDeclaration = (path) => readFileSync(path, 'utf8');
+const addJsExtensions = (declaration) =>
+	declaration.replace(/from '(\.[^']*?)(?<!\.js)'/g, "from '$1.js'");
+
+const sdkEsmDeclaration = () => addJsExtensions(readDeclaration('dist/sdk.d.ts'));
+const sdkCjsDeclaration = () =>
+	readDeclaration('dist/sdk.d.ts').replace(
+		"import type { ApiOptions, ApiResponse } from './types/api';",
+		'import type { ApiOptions, ApiResponse } from \'./types/api.js\' with { "resolution-mode": "import" };',
+	);
+
+const serviceNamesDeclaration = () => {
+	const declaration = readDeclaration('dist/services/index.d.ts');
+	const exportMatch = declaration.match(/export \{ (?<names>[^}]+) \};/);
+	if (!exportMatch?.groups?.names) {
+		throw new Error('Unable to locate services export list in dist/services/index.d.ts');
+	}
+
+	const serviceNames = exportMatch.groups.names
+		.split(',')
+		.map(name => name.trim())
+		.filter(Boolean);
+	const exports = serviceNames.map(name => `export declare const ${name}: ApiFunction;`);
+
+	return [
+		'import type { ApiFunction } from \'./types/api.js\' with { "resolution-mode": "import" };',
+		...exports,
+		'',
+	].join('\n');
+};
 
 writeFileSync('dist/app.d.cts', `${appDeclaration}export = app;\n`);
 writeFileSync('dist/index.d.cts', "import app = require('./app.cjs');\nexport = app;\n");
@@ -8,3 +38,10 @@ writeFileSync('dist/app.d.mts', `${appDeclaration}export default app;\n`);
 writeFileSync('dist/index.d.mts', "export { default } from './app.js';\n");
 writeFileSync('dist/app.d.ts', `${appDeclaration}export default app;\n`);
 writeFileSync('dist/index.d.ts', "export { default } from './app.js';\n");
+const servicesDeclaration = serviceNamesDeclaration();
+writeFileSync('dist/services.d.cts', servicesDeclaration);
+writeFileSync('dist/services.d.mts', servicesDeclaration);
+writeFileSync('dist/services.d.ts', servicesDeclaration);
+writeFileSync('dist/sdk.d.cts', sdkCjsDeclaration());
+writeFileSync('dist/sdk.d.mts', sdkEsmDeclaration());
+writeFileSync('dist/sdk.d.ts', readDeclaration('dist/sdk.d.ts'));

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,0 +1,130 @@
+import {
+	checkQQLoginQr,
+	getLyric,
+	getMusicPlay,
+	getQQLoginQr,
+	getSearchByKey,
+} from './services';
+import type { ApiOptions, ApiResponse } from './types/api';
+
+type RequestOption = ApiOptions['option'];
+
+export interface SearchOptions {
+	key: string;
+	limit?: number;
+	page?: number;
+	catZhida?: number;
+	remoteplace?: string;
+	option?: RequestOption;
+}
+
+export interface GetMusicPlayOptions {
+	songmid: string | string[];
+	quality?: string | number;
+	resType?: string;
+	mediaId?: string;
+	cookie?: string;
+	option?: RequestOption;
+}
+
+export interface GetLyricOptions {
+	songmid?: string;
+	songid?: string;
+	isFormat?: boolean | string;
+	cookie?: string;
+	option?: RequestOption;
+}
+
+export interface CheckQQLoginQrOptions {
+	ptqrtoken: string | number;
+	qrsig: string;
+}
+
+const withCookie = (option: RequestOption = {}, cookie?: string): RequestOption => {
+	if (!cookie) {
+		return option;
+	}
+
+	const headers = {
+		...(option as Record<string, any>).headers,
+		Cookie: cookie,
+	};
+
+	return {
+		...(option as Record<string, any>),
+		headers,
+	};
+};
+
+export const search = async ({
+	key,
+	limit = 10,
+	page = 1,
+	catZhida = 1,
+	remoteplace = 'song',
+	option = {},
+}: SearchOptions): Promise<ApiResponse> => getSearchByKey({
+	method: 'get',
+	params: {
+		w: key,
+		n: limit,
+		p: page,
+		catZhida,
+		remoteplace: `txt.yqq.${remoteplace}`,
+	},
+	option,
+});
+
+export const getPlayUrl = async ({
+	songmid,
+	quality,
+	resType = 'play',
+	mediaId,
+	cookie,
+	option = {},
+}: GetMusicPlayOptions): Promise<ApiResponse> => getMusicPlay({
+	method: 'get',
+	params: {
+		songmid,
+		quality,
+		resType,
+		mediaId,
+	},
+	option: withCookie(option, cookie),
+});
+
+export const lyric = async ({
+	songmid,
+	songid,
+	isFormat = false,
+	cookie,
+	option = {},
+}: GetLyricOptions): Promise<ApiResponse> => getLyric({
+	method: 'get',
+	params: {
+		songmid,
+		songid,
+	},
+	isFormat,
+	option: withCookie(option, cookie),
+});
+
+export const getLoginQr = async (): Promise<ApiResponse> => getQQLoginQr({});
+
+export const checkLoginQr = async ({
+	ptqrtoken,
+	qrsig,
+}: CheckQQLoginQrOptions): Promise<ApiResponse> => checkQQLoginQr({
+	method: 'post',
+	params: {
+		ptqrtoken,
+		qrsig,
+	},
+});
+
+export {
+	checkLoginQr as checkQQLoginQr,
+	getLoginQr as getQQLoginQr,
+	getPlayUrl as getMusicPlay,
+	lyric as getLyric,
+};

--- a/tests/integration/package-entry.test.ts
+++ b/tests/integration/package-entry.test.ts
@@ -62,11 +62,21 @@ const writeTypesFixture = () => {
 		path.join(typesDir, 'esm-consumer.mts'),
 		[
 			"import app from '@sansenjian/qq-music-api';",
+			"import { getMusicPlay } from '@sansenjian/qq-music-api/services';",
+			"import { checkQQLoginQr, getLyric, getMusicPlay as sdkGetMusicPlay, getQQLoginQr, search } from '@sansenjian/qq-music-api/sdk';",
 			"import type Koa = require('koa');",
 			'',
 			'const typedApp: Koa = app;',
 			'const callback: ReturnType<typeof typedApp.callback> = typedApp.callback();',
+			'const serviceResult = getMusicPlay({ params: { songmid: "003rJSwm3TechU" } });',
+			'const sdkResult = search({ key: "周杰伦" });',
 			'void callback;',
+			'void serviceResult;',
+			'void sdkResult;',
+			'void sdkGetMusicPlay;',
+			'void getLyric;',
+			'void getQQLoginQr;',
+			'void checkQQLoginQr;',
 			'',
 		].join('\n'),
 	);
@@ -88,11 +98,21 @@ const writeTypesFixture = () => {
 		path.join(typesDir, 'cjs-consumer.cts'),
 		[
 			"import app = require('@sansenjian/qq-music-api');",
+			"import { getMusicPlay } from '@sansenjian/qq-music-api/services';",
+			"import { checkQQLoginQr, getLyric, getMusicPlay as sdkGetMusicPlay, getQQLoginQr, search } from '@sansenjian/qq-music-api/sdk';",
 			"import type Koa = require('koa');",
 			'',
 			'const typedApp: Koa = app;',
 			'const callback: ReturnType<typeof typedApp.callback> = typedApp.callback();',
+			'const serviceResult = getMusicPlay({ params: { songmid: "003rJSwm3TechU" } });',
+			'const sdkResult = search({ key: "周杰伦" });',
 			'void callback;',
+			'void serviceResult;',
+			'void sdkResult;',
+			'void sdkGetMusicPlay;',
+			'void getLyric;',
+			'void getQQLoginQr;',
+			'void checkQQLoginQr;',
 			'',
 		].join('\n'),
 	);
@@ -278,6 +298,91 @@ describe('Package Entry Compatibility', () => {
 			]);
 
 			expect(stdout.trim()).toBe('cjs ok');
+			expect(fs.existsSync(configDir)).toBe(false);
+		},
+		60_000,
+	);
+
+	test(
+		'should expose service functions through the ESM services entry',
+		async () => {
+			const { stdout } = await runNode([
+				'--input-type=module',
+				'--eval',
+				`
+					const mod = await import('@sansenjian/qq-music-api/services');
+					if (typeof mod.getMusicPlay !== 'function' || typeof mod.getSearchByKey !== 'function') {
+						throw new Error('Expected ESM services entry to expose service functions');
+					}
+					console.log('esm services ok');
+				`,
+			]);
+
+			expect(stdout.trim()).toBe('esm services ok');
+			expect(fs.existsSync(configDir)).toBe(false);
+		},
+		60_000,
+	);
+
+	test(
+		'should expose service functions through the CJS services entry',
+		async () => {
+			const { stdout } = await runNode([
+				'--eval',
+				`
+					const mod = require('@sansenjian/qq-music-api/services');
+					if (typeof mod.getMusicPlay !== 'function' || typeof mod.getSearchByKey !== 'function') {
+						throw new Error('Expected CJS services entry to expose service functions');
+					}
+					console.log('cjs services ok');
+				`,
+			]);
+
+			expect(stdout.trim()).toBe('cjs services ok');
+			expect(fs.existsSync(configDir)).toBe(false);
+		},
+		60_000,
+	);
+
+	test(
+		'should expose SDK helpers through ESM and CJS sdk entries',
+		async () => {
+			const { stdout: esmStdout } = await runNode([
+				'--input-type=module',
+				'--eval',
+				`
+					const mod = await import('@sansenjian/qq-music-api/sdk');
+					if (
+						typeof mod.search !== 'function' ||
+						typeof mod.getMusicPlay !== 'function' ||
+						typeof mod.getLyric !== 'function' ||
+						typeof mod.getQQLoginQr !== 'function' ||
+						typeof mod.checkQQLoginQr !== 'function'
+					) {
+						throw new Error('Expected ESM sdk entry to expose helper functions');
+					}
+					console.log('esm sdk ok');
+				`,
+			]);
+			const { stdout: cjsStdout } = await runNode([
+				'--eval',
+				`
+					const mod = require('@sansenjian/qq-music-api/sdk');
+					if (
+						typeof mod.search !== 'function' ||
+						typeof mod.getMusicPlay !== 'function' ||
+						typeof mod.getLyric !== 'function' ||
+						typeof mod.getQQLoginQr !== 'function' ||
+						typeof mod.checkQQLoginQr !== 'function'
+					) {
+						throw new Error('Expected CJS sdk entry to expose helper functions');
+					}
+					console.log('cjs sdk ok');
+				`,
+			]);
+
+			expect(esmStdout.trim()).toBe('esm sdk ok');
+			expect(cjsStdout.trim()).toBe('cjs sdk ok');
 			expect(fs.existsSync(configDir)).toBe(false);
 		},
 		60_000,

--- a/tests/unit/sdk.test.ts
+++ b/tests/unit/sdk.test.ts
@@ -1,0 +1,112 @@
+import {
+	checkLoginQr,
+	getLoginQr,
+	getPlayUrl,
+	lyric,
+	search,
+} from '../../src/sdk';
+import {
+	checkQQLoginQr,
+	getLyric,
+	getMusicPlay,
+	getQQLoginQr,
+	getSearchByKey,
+} from '../../src/services';
+
+vi.mock('../../src/services', () => ({
+	checkQQLoginQr: vi.fn(),
+	getLyric: vi.fn(),
+	getMusicPlay: vi.fn(),
+	getQQLoginQr: vi.fn(),
+	getSearchByKey: vi.fn(),
+}));
+
+describe('sdk', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test('search maps simple SDK params to search service options', async () => {
+		vi.mocked(getSearchByKey).mockResolvedValue({ status: 200, body: { response: {} } });
+
+		await search({ key: '周杰伦', limit: 20, page: 2 });
+
+		expect(getSearchByKey).toHaveBeenCalledWith({
+			method: 'get',
+			params: {
+				w: '周杰伦',
+				n: 20,
+				p: 2,
+				catZhida: 1,
+				remoteplace: 'txt.yqq.song',
+			},
+			option: {},
+		});
+	});
+
+	test('getPlayUrl maps cookie to service headers', async () => {
+		vi.mocked(getMusicPlay).mockResolvedValue({ status: 200, body: { data: {} } });
+
+		await getPlayUrl({
+			songmid: '003rJSwm3TechU',
+			quality: '320',
+			cookie: 'uin=o123; qqmusic_key=secret',
+		});
+
+		expect(getMusicPlay).toHaveBeenCalledWith({
+			method: 'get',
+			params: {
+				songmid: '003rJSwm3TechU',
+				quality: '320',
+				resType: 'play',
+				mediaId: undefined,
+			},
+			option: {
+				headers: {
+					Cookie: 'uin=o123; qqmusic_key=secret',
+				},
+			},
+		});
+	});
+
+	test('lyric maps format and cookie to lyric service options', async () => {
+		vi.mocked(getLyric).mockResolvedValue({ status: 200, body: { response: {} } });
+
+		await lyric({
+			songmid: '003rJSwm3TechU',
+			isFormat: true,
+			cookie: 'uin=o123',
+		});
+
+		expect(getLyric).toHaveBeenCalledWith({
+			method: 'get',
+			params: {
+				songmid: '003rJSwm3TechU',
+				songid: undefined,
+			},
+			isFormat: true,
+			option: {
+				headers: {
+					Cookie: 'uin=o123',
+				},
+			},
+		});
+	});
+
+	test('login QR helpers call existing login services', async () => {
+		vi.mocked(getQQLoginQr).mockResolvedValue({ status: 200, body: { response: {} } });
+		vi.mocked(checkQQLoginQr).mockResolvedValue({ status: 200, body: { response: {} } });
+
+		await getLoginQr();
+		await checkLoginQr({ ptqrtoken: 123, qrsig: 'abc' });
+
+		expect(getQQLoginQr).toHaveBeenCalledWith({});
+		expect(checkQQLoginQr).toHaveBeenCalledWith({
+			method: 'post',
+			params: {
+				ptqrtoken: 123,
+				qrsig: 'abc',
+			},
+		});
+	});
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,16 @@
 import { defineConfig, normalizePath } from 'vite';
 import { resolve } from 'node:path';
+import { builtinModules } from 'node:module';
 import { oxcTransform } from './plugins/vite-plugin-oxc-transform';
 import type { Plugin } from 'vite';
 
+const nodeBuiltins = [
+	...builtinModules,
+	...builtinModules.map(moduleName => `node:${moduleName}`),
+];
+
 const externalPackages = [
+	...nodeBuiltins,
 	'koa',
 	'@koa/router',
 	'axios',
@@ -58,6 +65,8 @@ export default defineConfig({
 				app: resolve(__dirname, 'src/app.ts'),
 				cli: resolve(__dirname, 'src/cli.ts'),
 				index: resolve(__dirname, 'src/index.ts'),
+				services: resolve(__dirname, 'src/services/index.ts'),
+				sdk: resolve(__dirname, 'src/sdk.ts'),
 			},
 			formats: ['es', 'cjs'],
 		},


### PR DESCRIPTION
#24

## Summary by Sourcery

为直接在 Node.js 中使用提供类型化的 service 和 SDK 入口点，同时保留现有的 Koa 应用导出。

新功能：
- 新增 `./services` 入口，暴露底层 QQ 音乐服务函数，提供 ESM 和 CJS 构建以及类型声明。
- 新增 `./sdk` 入口，提供更高层的辅助函数，用于搜索、播放链接、歌词以及 QQ 登录二维码流程，并附带完整的 TypeScript 配置项与响应类型。

增强：
- 扩展构建配置以打包 services 和 SDK 输出，并将 Node 内置模块标记为外部依赖。
- 为新的 services 和 SDK 入口生成并发布 TypeScript 声明文件，包括 CJS/ESM 变体。

文档：
- 在 README 中记录 SDK 风格的函数式用法，并新增一个专门的 SDK 使用指南页面，从导航和快速开始指南中进行链接。

测试：
- 扩展集成测试，以验证 services 和 SDK 函数能通过 ESM 和 CJS 入口正确暴露，并可从类型夹具中正常使用。
- 为新的 SDK 模块添加单元测试脚手架。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose typed service and SDK entry points for direct Node.js consumption alongside the existing Koa app export.

New Features:
- Add ./services entry that exposes underlying QQ Music service functions with ESM and CJS builds and type declarations.
- Add ./sdk entry that provides higher-level helper functions for search, playback URLs, lyrics, and QQ login QR flows, with full TypeScript options and responses.

Enhancements:
- Extend the build configuration to bundle services and SDK outputs and mark Node built-in modules as external dependencies.
- Generate and publish TypeScript declaration files for the new services and SDK entry points, including CJS/ESM variants.

Documentation:
- Document SDK-style functional usage in the README and add a dedicated SDK usage guide page linked from the navigation and quickstart guide.

Tests:
- Expand integration tests to verify services and SDK functions are exposed correctly via ESM and CJS entries and consumable from type fixtures.
- Add unit test scaffolding for the new SDK module.

</details>

新功能：
- 在 `./services` 导出路径下，为底层服务函数添加带类型定义的 ESM/CJS 入口。
- 在 `./sdk` 下添加一个高级 SDK 入口，提供用于搜索、播放地址、歌词以及 QQ 登录二维码流程的辅助函数。

增强：
- 在构建产物中生成并发布新服务和 SDK 入口的类型声明。
- 扩展 Vite 构建配置，以打包服务和 SDK 输出，并将 Node 内置模块视为 external 依赖。

文档：
- 在 README 中记录 QQ 音乐 API 的 SDK 风格函数式用法，并新增一页专门的 SDK 使用指南，从导航和快速上手指南中链接到该页面。

测试：
- 添加集成测试，验证服务和 SDK 函数通过 ESM 和 CJS 入口正确暴露，包括类型消费（type-consumer）夹具。
- 为新的 SDK 模块添加（占位）单元测试覆盖的脚手架。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为直接在 Node.js 中使用提供类型化的 service 和 SDK 入口点，同时保留现有的 Koa 应用导出。

新功能：
- 新增 `./services` 入口，暴露底层 QQ 音乐服务函数，提供 ESM 和 CJS 构建以及类型声明。
- 新增 `./sdk` 入口，提供更高层的辅助函数，用于搜索、播放链接、歌词以及 QQ 登录二维码流程，并附带完整的 TypeScript 配置项与响应类型。

增强：
- 扩展构建配置以打包 services 和 SDK 输出，并将 Node 内置模块标记为外部依赖。
- 为新的 services 和 SDK 入口生成并发布 TypeScript 声明文件，包括 CJS/ESM 变体。

文档：
- 在 README 中记录 SDK 风格的函数式用法，并新增一个专门的 SDK 使用指南页面，从导航和快速开始指南中进行链接。

测试：
- 扩展集成测试，以验证 services 和 SDK 函数能通过 ESM 和 CJS 入口正确暴露，并可从类型夹具中正常使用。
- 为新的 SDK 模块添加单元测试脚手架。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose typed service and SDK entry points for direct Node.js consumption alongside the existing Koa app export.

New Features:
- Add ./services entry that exposes underlying QQ Music service functions with ESM and CJS builds and type declarations.
- Add ./sdk entry that provides higher-level helper functions for search, playback URLs, lyrics, and QQ login QR flows, with full TypeScript options and responses.

Enhancements:
- Extend the build configuration to bundle services and SDK outputs and mark Node built-in modules as external dependencies.
- Generate and publish TypeScript declaration files for the new services and SDK entry points, including CJS/ESM variants.

Documentation:
- Document SDK-style functional usage in the README and add a dedicated SDK usage guide page linked from the navigation and quickstart guide.

Tests:
- Expand integration tests to verify services and SDK functions are exposed correctly via ESM and CJS entries and consumable from type fixtures.
- Add unit test scaffolding for the new SDK module.

</details>

</details>