### PR TITLE
feat(exports): expose Koa app entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,19 +60,30 @@ npm install @sansenjian/qq-music-api
 
 NPM 包默认包含运行所需的 `dist/`、本地交互测试页 `public/`，以及已构建的文档站点 `docs-dist/`。如果你只想在自己的发布产物中保留 API 运行时，可以在你的项目打包配置中自行排除 `node_modules/@sansenjian/qq-music-api/docs-dist/` 或 `node_modules/@sansenjian/qq-music-api/public/`。
 
-在项目中使用：
+### 包入口
+
+- `@sansenjian/qq-music-api`：默认入口，导出 Koa app，适合保持现有部署代码不变。
+- `@sansenjian/qq-music-api/app`：显式的 Koa app 入口，推荐在已有 Node.js 或 Electron 进程中嵌入服务。
+- `@sansenjian/qq-music-api/sdk`：函数式 SDK，不启动 HTTP 服务。
+- `@sansenjian/qq-music-api/services`：底层 service 函数入口。
+
+嵌入已有 Node.js 进程时，使用公开的 `app` 子路径，不要依赖 `dist/*` 私有构建路径：
 
 ```javascript
-const { spawn } = require('child_process');
-const path = require('path');
+// ESM
+import app from '@sansenjian/qq-music-api/app';
 
-const qqMusicPath = path.join(__dirname, 'node_modules', '@sansenjian/qq-music-api', 'dist', 'app.js');
-
-spawn('node', [qqMusicPath], {
-	env: { ...process.env, PORT: '3200' },
-	stdio: 'inherit',
-});
+app.listen(process.env.PORT || 3200);
 ```
+
+```javascript
+// CommonJS
+const app = require('@sansenjian/qq-music-api/app');
+
+app.listen(process.env.PORT || 3200);
+```
+
+如果需要启动独立 HTTP 服务，请使用项目的 `npm run start` 或已发布包提供的 `qq-music-api` CLI，而不是直接拼接 `dist/app.js` 路径。
 
 也可以直接在 Node.js 项目中函数式调用，不需要单独启动 HTTP 服务：
 

--- a/docs/guide/sdk-usage.md
+++ b/docs/guide/sdk-usage.md
@@ -81,5 +81,12 @@ await getMusicPlay({
 ## 与 HTTP 服务的关系
 
 - `@sansenjian/qq-music-api` 默认入口仍然导出 Koa app，现有部署方式不变。
+- `@sansenjian/qq-music-api/app` 显式导出 Koa app，适合嵌入已有 Node.js 或 Electron 进程；不要依赖 `dist/*` 私有路径。
 - `@sansenjian/qq-music-api/sdk` 不启动 HTTP 服务。
 - `@sansenjian/qq-music-api/services` 面向需要底层参数控制的调用方，返回结构与现有 service 层保持一致。
+
+```ts
+import app from '@sansenjian/qq-music-api/app'
+
+app.listen(process.env.PORT || 3200)
+```

--- a/package.json
+++ b/package.json
@@ -24,6 +24,16 @@
 				"default": "./dist/index.cjs"
 			}
 		},
+		"./app": {
+			"import": {
+				"types": "./dist/app.d.mts",
+				"default": "./dist/app.js"
+			},
+			"require": {
+				"types": "./dist/app.d.cts",
+				"default": "./dist/app.cjs"
+			}
+		},
 		"./services": {
 			"import": {
 				"types": "./dist/services.d.mts",

--- a/tests/integration/package-entry.test.ts
+++ b/tests/integration/package-entry.test.ts
@@ -62,15 +62,19 @@ const writeTypesFixture = () => {
 		path.join(typesDir, 'esm-consumer.mts'),
 		[
 			"import app from '@sansenjian/qq-music-api';",
+			"import appEntry from '@sansenjian/qq-music-api/app';",
 			"import { getMusicPlay } from '@sansenjian/qq-music-api/services';",
 			"import { checkQQLoginQr, getLyric, getMusicPlay as sdkGetMusicPlay, getQQLoginQr, search } from '@sansenjian/qq-music-api/sdk';",
 			"import type Koa = require('koa');",
 			'',
 			'const typedApp: Koa = app;',
+			'const typedAppEntry: Koa = appEntry;',
 			'const callback: ReturnType<typeof typedApp.callback> = typedApp.callback();',
+			'const appEntryCallback: ReturnType<typeof typedAppEntry.callback> = typedAppEntry.callback();',
 			'const serviceResult = getMusicPlay({ params: { songmid: "003rJSwm3TechU" } });',
 			'const sdkResult = search({ key: "周杰伦" });',
 			'void callback;',
+			'void appEntryCallback;',
 			'void serviceResult;',
 			'void sdkResult;',
 			'void sdkGetMusicPlay;',
@@ -98,15 +102,19 @@ const writeTypesFixture = () => {
 		path.join(typesDir, 'cjs-consumer.cts'),
 		[
 			"import app = require('@sansenjian/qq-music-api');",
+			"import appEntry = require('@sansenjian/qq-music-api/app');",
 			"import { getMusicPlay } from '@sansenjian/qq-music-api/services';",
 			"import { checkQQLoginQr, getLyric, getMusicPlay as sdkGetMusicPlay, getQQLoginQr, search } from '@sansenjian/qq-music-api/sdk';",
 			"import type Koa = require('koa');",
 			'',
 			'const typedApp: Koa = app;',
+			'const typedAppEntry: Koa = appEntry;',
 			'const callback: ReturnType<typeof typedApp.callback> = typedApp.callback();',
+			'const appEntryCallback: ReturnType<typeof typedAppEntry.callback> = typedAppEntry.callback();',
 			'const serviceResult = getMusicPlay({ params: { songmid: "003rJSwm3TechU" } });',
 			'const sdkResult = search({ key: "周杰伦" });',
 			'void callback;',
+			'void appEntryCallback;',
 			'void serviceResult;',
 			'void sdkResult;',
 			'void sdkGetMusicPlay;',
@@ -298,6 +306,50 @@ describe('Package Entry Compatibility', () => {
 			]);
 
 			expect(stdout.trim()).toBe('cjs ok');
+			expect(fs.existsSync(configDir)).toBe(false);
+		},
+		60_000,
+	);
+
+	test(
+		'should load the explicit app subpath through ESM import',
+		async () => {
+			const { stdout } = await runNode([
+				'--input-type=module',
+				'--eval',
+				`
+					const mod = await import('@sansenjian/qq-music-api/app');
+					if (typeof mod.default?.callback !== 'function') {
+						throw new Error('Expected ESM app entry to expose a Koa app');
+					}
+					console.log('esm app ok');
+				`,
+			]);
+
+			expect(stdout.trim()).toBe('esm app ok');
+			expect(fs.existsSync(configDir)).toBe(false);
+		},
+		60_000,
+	);
+
+	test(
+		'should load the explicit app subpath through CJS require',
+		async () => {
+			const { stdout } = await runNode([
+				'--eval',
+				`
+					const mod = require('@sansenjian/qq-music-api/app');
+					if (typeof mod.callback !== 'function') {
+						throw new Error('Expected CJS app entry to expose a Koa app');
+					}
+					if (Object.prototype.hasOwnProperty.call(mod, 'default')) {
+						throw new Error('Expected CJS app entry to work without a .default wrapper');
+					}
+					console.log('cjs app ok');
+				`,
+			]);
+
+			expect(stdout.trim()).toBe('cjs app ok');
 			expect(fs.existsSync(configDir)).toBe(false);
 		},
 		60_000,


### PR DESCRIPTION
## Summary

- add a stable `@sansenjian/qq-music-api/app` export for ESM and CommonJS consumers
- document root, app, SDK, and services package entry points without relying on `dist/*`
- cover the app subpath at runtime and through Node16/Bundler type resolution

## Validation

- `npm run lint`
- `npm run test`
- `npm run build`
- `npm run docs:build`

Closes #37