### PR TITLE
chore(vercel): 为 api/index.ts 增加 includeFiles 以支持 Vercel 部署

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -5,7 +5,7 @@ export default defineConfig({
   lang: 'zh-CN',
   title: 'QQ Music API',
   description: 'QQ 音乐 API 接口文档',
-  base: '/qq-music-api/',
+  base: process.env.VERCEL ? '/' : '/qq-music-api/',
   outDir: '../docs-dist',
   lastUpdated: true,
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
 	"name": "@sansenjian/qq-music-api",
 	"version": "2.4.0",
 	"packageManager": "npm@11.14.1",
-	"workspaces": [
-		"packages/mcp"
-	],
 	"publishConfig": {
 		"access": "public"
 	},

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "@sansenjian/qq-music-api",
 	"version": "2.4.0",
 	"packageManager": "npm@11.14.1",
+	"workspaces": [
+		"packages/mcp"
+	],
 	"publishConfig": {
 		"access": "public"
 	},

--- a/public/explorer/app.js
+++ b/public/explorer/app.js
@@ -30,8 +30,10 @@
 		requestUrl: getRequiredElement("request-url"),
 		sendButton: getRequiredElement("send-button"),
 		resetButton: getRequiredElement("reset-button"),
+		copyUrlButton: getRequiredElement("copy-url-button"),
 		responseMeta: getRequiredElement("response-meta"),
 		responseOutput: getRequiredElement("response-output"),
+		copyResponseButton: getRequiredElement("copy-response-button"),
 		requestLogs: getRequiredElement("request-logs"),
 		clearLogsButton: getRequiredElement("clear-logs-button")
 	});
@@ -72,6 +74,47 @@
 			logs: []
 		};
 		const elements = getElements();
+		const setResponse = (meta, text, responseState) => {
+			elements.responseMeta.textContent = meta;
+			elements.responseMeta.dataset.state = responseState;
+			elements.responseOutput.textContent = text;
+			elements.responseOutput.dataset.state = responseState;
+			elements.copyResponseButton.disabled = responseState === "idle" || responseState === "loading";
+		};
+		const clearResponse = () => {
+			setResponse("等待请求", "发送请求后，响应会显示在这里。", "idle");
+		};
+		const copyText = async (value) => {
+			if (navigator.clipboard?.writeText) {
+				await navigator.clipboard.writeText(value);
+				return;
+			}
+			const textarea = document.createElement("textarea");
+			textarea.value = value;
+			textarea.style.position = "fixed";
+			textarea.style.opacity = "0";
+			document.body.append(textarea);
+			try {
+				textarea.select();
+				if (!document.execCommand("copy")) throw new Error("当前浏览器不支持复制");
+			} finally {
+				textarea.remove();
+			}
+		};
+		const withCopyFeedback = async (button, value) => {
+			const defaultLabel = button.dataset.defaultLabel || button.textContent || "复制";
+			button.dataset.defaultLabel = defaultLabel;
+			try {
+				await copyText(value);
+				button.textContent = "已复制";
+			} catch {
+				button.textContent = "复制失败";
+			} finally {
+				window.setTimeout(() => {
+					button.textContent = defaultLabel;
+				}, 1400);
+			}
+		};
 		const setEndpointCount = () => {
 			const total = state.endpoints.length;
 			const visible = state.filteredEndpoints.length;
@@ -105,6 +148,10 @@
 		const updateRequestUrl = () => {
 			elements.requestUrl.textContent = buildUrl();
 		};
+		const captureParamValues = (endpoint) => ({
+			pathParams: Object.fromEntries(getPathParams(getActivePath(endpoint)).map((name) => [name, getInputValue("path", name)])),
+			queryParams: Object.fromEntries((endpoint.queryParams || []).map((param) => [param.name, getInputValue("query", param.name)]).filter(([, value]) => value))
+		});
 		const createField = (kind, param) => {
 			const label = document.createElement("label");
 			label.className = "field";
@@ -157,6 +204,7 @@
 			const endpoint = state.activeEndpoint;
 			elements.sendButton.disabled = !endpoint;
 			elements.resetButton.disabled = !endpoint;
+			elements.copyUrlButton.disabled = !endpoint;
 			if (!endpoint) {
 				elements.activeCategory.textContent = "未选择";
 				elements.activeName.textContent = "选择一个接口";
@@ -167,6 +215,7 @@
 				elements.bodySection.classList.add("hidden");
 				elements.bodyInput.value = "";
 				updateRequestUrl();
+				clearResponse();
 				return;
 			}
 			const pathParams = getPathParams(getActivePath(endpoint)).map((name) => ({
@@ -248,6 +297,7 @@
 					state.activeEndpoint = endpoint;
 					renderEndpointList();
 					renderActiveEndpoint();
+					clearResponse();
 				});
 				elements.endpointList.append(button);
 			}
@@ -288,26 +338,40 @@
 				const item = document.createElement("button");
 				item.type = "button";
 				item.className = "log-item";
+				item.dataset.state = log.status === "ERR" || typeof log.status === "number" && log.status >= 400 ? "error" : "success";
 				const summary = document.createElement("strong");
 				summary.textContent = `${log.method} ${log.endpointName}`;
 				const meta = document.createElement("span");
 				meta.textContent = `${log.status} · ${log.duration}ms · ${log.url}`;
 				item.append(summary, meta);
 				item.addEventListener("click", () => {
-					elements.responseMeta.textContent = `${log.status} · ${log.duration}ms`;
-					elements.requestUrl.textContent = log.url;
+					const endpoint = state.endpoints.find((candidate) => candidate.name === log.endpointName);
+					if (!endpoint) return;
+					state.activeEndpoint = endpoint;
+					renderEndpointList();
+					renderActiveEndpoint();
+					Object.entries(log.pathParams).forEach(([name, value]) => setInputValue("path", name, value));
+					Object.entries(log.queryParams).forEach(([name, value]) => setInputValue("query", name, value));
+					elements.bodyInput.value = log.body;
+					updateRequestUrl();
+					setResponse(log.responseMeta, log.responseText, log.status === "ERR" || typeof log.status === "number" && log.status >= 400 ? "error" : "success");
 				});
 				elements.requestLogs.append(item);
 			});
 		};
-		const addLog = ({ endpoint, url, status, duration }) => {
+		const addLog = ({ endpoint, url, status, duration, pathParams, queryParams, body, responseMeta, responseText }) => {
 			state.logs.unshift({
 				id: Date.now(),
 				endpointName: endpoint.name,
 				method: endpoint.method,
 				url,
 				status,
-				duration
+				duration,
+				pathParams,
+				queryParams,
+				body,
+				responseMeta,
+				responseText
 			});
 			state.logs = state.logs.slice(0, 30);
 			renderLogs();
@@ -318,41 +382,58 @@
 			if (!endpoint) return;
 			const url = buildUrl();
 			const init = { method: endpoint.method };
+			const requestParams = captureParamValues(endpoint);
+			const requestBody = elements.bodyInput.value;
 			if (endpoint.method !== "GET") {
 				const rawBody = elements.bodyInput.value.trim();
 				if (rawBody) try {
 					init.body = JSON.stringify(JSON.parse(rawBody));
 					init.headers = { "Content-Type": "application/json" };
 				} catch (error) {
-					elements.responseMeta.textContent = "JSON 格式错误";
-					elements.responseOutput.textContent = error instanceof Error ? error.message : String(error);
+					setResponse("JSON 格式错误", error instanceof Error ? error.message : String(error), "error");
 					return;
 				}
 			}
 			elements.sendButton.disabled = true;
-			elements.responseMeta.textContent = "请求中...";
+			setResponse("请求中...", "正在等待服务响应...", "loading");
 			const startedAt = performance.now();
 			try {
 				const response = await fetch(url, init);
 				const duration = Math.round(performance.now() - startedAt);
-				const body = (response.headers.get("content-type") || "").includes("application/json") ? await response.json() : await response.text();
-				elements.responseMeta.textContent = `${response.status} ${response.statusText} · ${duration}ms`;
-				elements.responseOutput.textContent = typeof body === "string" ? body : formatJson(body);
+				const contentType = response.headers.get("content-type") || "";
+				const rawBody = await response.text();
+				let responseText = rawBody;
+				if (contentType.includes("application/json") && rawBody) try {
+					responseText = formatJson(JSON.parse(rawBody));
+				} catch {
+					responseText = rawBody;
+				}
+				const responseMeta = `${response.status} ${response.statusText} · ${duration}ms`;
+				setResponse(responseMeta, responseText, response.ok ? "success" : "error");
 				addLog({
 					endpoint,
 					url,
 					status: response.status,
-					duration
+					duration,
+					...requestParams,
+					body: requestBody,
+					responseMeta,
+					responseText
 				});
 			} catch (error) {
 				const duration = Math.round(performance.now() - startedAt);
-				elements.responseMeta.textContent = `请求失败 · ${duration}ms`;
-				elements.responseOutput.textContent = error instanceof Error ? error.message : String(error);
+				const responseMeta = `请求失败 · ${duration}ms`;
+				const responseText = error instanceof Error ? error.message : String(error);
+				setResponse(responseMeta, responseText, "error");
 				addLog({
 					endpoint,
 					url,
 					status: "ERR",
-					duration
+					duration,
+					...requestParams,
+					body: requestBody,
+					responseMeta,
+					responseText
 				});
 			} finally {
 				elements.sendButton.disabled = false;
@@ -360,6 +441,7 @@
 		};
 		const resetActiveEndpoint = () => {
 			renderActiveEndpoint();
+			clearResponse();
 		};
 		const loadMetadata = async () => {
 			const response = await fetch(metadataPath);
@@ -379,15 +461,29 @@
 		elements.requestForm.addEventListener("submit", (event) => {
 			submitRequest(event);
 		});
+		elements.requestForm.addEventListener("keydown", (event) => {
+			if ((event.ctrlKey || event.metaKey) && event.key === "Enter" && !elements.sendButton.disabled) {
+				event.preventDefault();
+				submitRequest(new SubmitEvent("submit", {
+					bubbles: true,
+					cancelable: true
+				}));
+			}
+		});
 		elements.resetButton.addEventListener("click", resetActiveEndpoint);
+		elements.copyUrlButton.addEventListener("click", () => {
+			withCopyFeedback(elements.copyUrlButton, buildUrl());
+		});
+		elements.copyResponseButton.addEventListener("click", () => {
+			withCopyFeedback(elements.copyResponseButton, elements.responseOutput.textContent || "");
+		});
 		elements.clearLogsButton.addEventListener("click", () => {
 			state.logs = [];
 			renderLogs();
 		});
 		loadMetadata().catch((error) => {
 			elements.endpointCount.textContent = "接口加载失败";
-			elements.responseMeta.textContent = "加载失败";
-			elements.responseOutput.textContent = error instanceof Error ? error.message : String(error);
+			setResponse("加载失败", error instanceof Error ? error.message : String(error), "error");
 		});
 	};
 	initExplorerApp();

--- a/public/explorer/index.html
+++ b/public/explorer/index.html
@@ -67,7 +67,8 @@
 						</label>
 
 						<div class="url-box">
-							<span id="request-url">/</span>
+							<code id="request-url">/</code>
+							<button id="copy-url-button" type="button" title="复制当前请求地址">复制 URL</button>
 						</div>
 
 						<div class="actions">
@@ -78,12 +79,15 @@
 				</section>
 
 				<section class="result-panel" aria-label="响应和日志">
-					<div class="response-box">
+				<div class="response-box">
 						<div class="section-heading">
 							<h2>响应</h2>
-							<span id="response-meta">等待请求</span>
+							<div class="section-actions">
+								<span id="response-meta" aria-live="polite" data-state="idle">等待请求</span>
+								<button id="copy-response-button" type="button" title="复制响应内容" disabled>复制响应</button>
+							</div>
 						</div>
-						<pre id="response-output">{}</pre>
+						<pre id="response-output">发送请求后，响应会显示在这里。</pre>
 					</div>
 
 					<div class="log-box">

--- a/public/explorer/styles.css
+++ b/public/explorer/styles.css
@@ -44,9 +44,9 @@ a {
 }
 
 .app-shell {
-	width: min(1440px, calc(100% - 28px));
+	width: min(1480px, calc(100% - 32px));
 	margin: 0 auto;
-	padding: 22px 0 34px;
+	padding: 24px 0 40px;
 }
 
 .topbar {
@@ -128,6 +128,27 @@ button.primary {
 	background: var(--brand);
 }
 
+button:hover:not(:disabled),
+.nav a:hover {
+	border-color: var(--brand);
+	color: var(--brand-strong);
+}
+
+button.primary:hover:not(:disabled) {
+	border-color: var(--brand-strong);
+	color: #ffffff;
+	background: var(--brand-strong);
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+	outline: 3px solid rgba(46, 109, 230, 0.3);
+	outline-offset: 2px;
+}
+
 button:disabled {
 	cursor: not-allowed;
 	opacity: 0.58;
@@ -151,6 +172,9 @@ button:disabled {
 
 .sidebar {
 	overflow: hidden;
+	min-width: 0;
+	position: sticky;
+	top: 16px;
 }
 
 .filters {
@@ -289,6 +313,11 @@ textarea:focus {
 	padding: 16px;
 }
 
+.request-panel,
+.result-panel {
+	min-width: 0;
+}
+
 .panel-header {
 	display: flex;
 	justify-content: space-between;
@@ -348,6 +377,10 @@ textarea:focus {
 }
 
 .url-box {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 10px;
 	min-height: 44px;
 	border: 1px solid var(--line);
 	border-radius: 7px;
@@ -356,6 +389,20 @@ textarea:focus {
 	background: var(--surface-soft);
 	font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
 	font-size: 13px;
+}
+
+.url-box code {
+	min-width: 0;
+	color: var(--text);
+	white-space: pre-wrap;
+}
+
+.url-box button,
+.section-actions button,
+.log-box .section-heading button {
+	min-height: 32px;
+	padding: 0 10px;
+	font-size: 12px;
 }
 
 .actions {
@@ -377,8 +424,35 @@ textarea:focus {
 	margin-bottom: 12px;
 }
 
+.section-actions {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 8px;
+	min-width: 0;
+}
+
 .section-heading h2 {
 	font-size: 18px;
+}
+
+#response-meta {
+	color: var(--muted);
+	font-size: 12px;
+	font-weight: 700;
+	text-align: right;
+}
+
+#response-meta[data-state='loading'] {
+	color: var(--amber);
+}
+
+#response-meta[data-state='success'] {
+	color: var(--brand-strong);
+}
+
+#response-meta[data-state='error'] {
+	color: var(--red);
 }
 
 #response-output {
@@ -394,6 +468,11 @@ textarea:focus {
 	font-size: 13px;
 	line-height: 1.55;
 	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+#response-output[data-state='error'] {
+	color: #ffd8d8;
 }
 
 .request-logs {
@@ -404,10 +483,22 @@ textarea:focus {
 }
 
 .log-item {
+	display: grid;
+	width: 100%;
+	justify-content: stretch;
 	border: 1px solid var(--line);
 	border-radius: 7px;
 	padding: 9px 10px;
 	background: var(--surface-soft);
+	text-align: left;
+}
+
+.log-item[data-state='success'] {
+	border-left: 3px solid var(--brand);
+}
+
+.log-item[data-state='error'] {
+	border-left: 3px solid var(--red);
 }
 
 .log-item strong {
@@ -437,6 +528,10 @@ textarea:focus {
 		grid-column: 1 / -1;
 		grid-template-columns: 1fr 1fr;
 	}
+
+	.sidebar {
+		position: static;
+	}
 }
 
 @media (max-width: 820px) {
@@ -463,5 +558,22 @@ textarea:focus {
 	.param-section,
 	.filter-grid {
 		grid-template-columns: 1fr;
+	}
+
+	.url-box {
+		grid-template-columns: 1fr;
+	}
+
+	.url-box button {
+		width: 100%;
+	}
+
+	.section-actions {
+		width: 100%;
+		justify-content: space-between;
+	}
+
+	#response-meta {
+		text-align: left;
 	}
 }

--- a/src/explorer/explorerApp.ts
+++ b/src/explorer/explorerApp.ts
@@ -3,7 +3,6 @@
 type ApiMethod = 'GET' | 'POST' | 'DELETE';
 type ParamValue = string | number | boolean;
 type ParamKind = 'path' | 'query';
-type ResponseBody = string | Record<string, unknown> | unknown[];
 
 interface ApiParamMetadata {
 	name: string;
@@ -36,6 +35,11 @@ interface RequestLog {
 	url: string;
 	status: number | 'ERR';
 	duration: number;
+	pathParams: Record<string, string>;
+	queryParams: Record<string, string>;
+	body: string;
+	responseMeta: string;
+	responseText: string;
 }
 
 interface ExplorerState {
@@ -63,8 +67,10 @@ interface ExplorerElements {
 	requestUrl: HTMLElement;
 	sendButton: HTMLButtonElement;
 	resetButton: HTMLButtonElement;
+	copyUrlButton: HTMLButtonElement;
 	responseMeta: HTMLElement;
 	responseOutput: HTMLElement;
+	copyResponseButton: HTMLButtonElement;
 	requestLogs: HTMLElement;
 	clearLogsButton: HTMLButtonElement;
 }
@@ -102,8 +108,10 @@ const getElements = (): ExplorerElements => ({
 	requestUrl: getRequiredElement('request-url'),
 	sendButton: getRequiredElement<HTMLButtonElement>('send-button'),
 	resetButton: getRequiredElement<HTMLButtonElement>('reset-button'),
+	copyUrlButton: getRequiredElement<HTMLButtonElement>('copy-url-button'),
 	responseMeta: getRequiredElement('response-meta'),
 	responseOutput: getRequiredElement('response-output'),
+	copyResponseButton: getRequiredElement<HTMLButtonElement>('copy-response-button'),
 	requestLogs: getRequiredElement('request-logs'),
 	clearLogsButton: getRequiredElement<HTMLButtonElement>('clear-logs-button'),
 });
@@ -164,6 +172,52 @@ export const initExplorerApp = (options: ExplorerAppOptions = {}): void => {
 	};
 	const elements = getElements();
 
+	const setResponse = (meta: string, text: string, responseState: 'idle' | 'loading' | 'success' | 'error'): void => {
+		elements.responseMeta.textContent = meta;
+		elements.responseMeta.dataset.state = responseState;
+		elements.responseOutput.textContent = text;
+		elements.responseOutput.dataset.state = responseState;
+		elements.copyResponseButton.disabled = responseState === 'idle' || responseState === 'loading';
+	};
+
+	const clearResponse = (): void => {
+		setResponse('等待请求', '发送请求后，响应会显示在这里。', 'idle');
+	};
+
+	const copyText = async (value: string): Promise<void> => {
+		if (navigator.clipboard?.writeText) {
+			await navigator.clipboard.writeText(value);
+			return;
+		}
+
+		const textarea = document.createElement('textarea');
+		textarea.value = value;
+		textarea.style.position = 'fixed';
+		textarea.style.opacity = '0';
+		document.body.append(textarea);
+		try {
+			textarea.select();
+			if (!document.execCommand('copy')) throw new Error('当前浏览器不支持复制');
+		} finally {
+			textarea.remove();
+		}
+	};
+
+	const withCopyFeedback = async (button: HTMLButtonElement, value: string): Promise<void> => {
+		const defaultLabel = button.dataset.defaultLabel || button.textContent || '复制';
+		button.dataset.defaultLabel = defaultLabel;
+		try {
+			await copyText(value);
+			button.textContent = '已复制';
+		} catch {
+			button.textContent = '复制失败';
+		} finally {
+			window.setTimeout(() => {
+				button.textContent = defaultLabel;
+			}, 1400);
+		}
+	};
+
 	const setEndpointCount = () => {
 		const total = state.endpoints.length;
 		const visible = state.filteredEndpoints.length;
@@ -204,6 +258,17 @@ export const initExplorerApp = (options: ExplorerAppOptions = {}): void => {
 	const updateRequestUrl = (): void => {
 		elements.requestUrl.textContent = buildUrl();
 	};
+
+	const captureParamValues = (endpoint: ApiMetadataItem): { pathParams: Record<string, string>; queryParams: Record<string, string> } => ({
+		pathParams: Object.fromEntries(
+			getPathParams(getActivePath(endpoint)).map(name => [name, getInputValue('path', name)]),
+		),
+		queryParams: Object.fromEntries(
+			(endpoint.queryParams || [])
+				.map(param => [param.name, getInputValue('query', param.name)] as const)
+				.filter(([, value]) => value),
+		),
+	});
 
 	const createField = (kind: ParamKind, param: ApiParamMetadata): HTMLLabelElement => {
 		const label = document.createElement('label');
@@ -274,6 +339,7 @@ export const initExplorerApp = (options: ExplorerAppOptions = {}): void => {
 		const endpoint = state.activeEndpoint;
 		elements.sendButton.disabled = !endpoint;
 		elements.resetButton.disabled = !endpoint;
+		elements.copyUrlButton.disabled = !endpoint;
 
 		if (!endpoint) {
 			elements.activeCategory.textContent = '未选择';
@@ -285,6 +351,7 @@ export const initExplorerApp = (options: ExplorerAppOptions = {}): void => {
 			elements.bodySection.classList.add('hidden');
 			elements.bodyInput.value = '';
 			updateRequestUrl();
+			clearResponse();
 			return;
 		}
 
@@ -393,6 +460,7 @@ export const initExplorerApp = (options: ExplorerAppOptions = {}): void => {
 				state.activeEndpoint = endpoint;
 				renderEndpointList();
 				renderActiveEndpoint();
+				clearResponse();
 			});
 			elements.endpointList.append(button);
 		}
@@ -446,6 +514,7 @@ export const initExplorerApp = (options: ExplorerAppOptions = {}): void => {
 			const item = document.createElement('button');
 			item.type = 'button';
 			item.className = 'log-item';
+			item.dataset.state = log.status === 'ERR' || (typeof log.status === 'number' && log.status >= 400) ? 'error' : 'success';
 
 			const summary = document.createElement('strong');
 			summary.textContent = `${log.method} ${log.endpointName}`;
@@ -455,8 +524,17 @@ export const initExplorerApp = (options: ExplorerAppOptions = {}): void => {
 
 			item.append(summary, meta);
 			item.addEventListener('click', () => {
-				elements.responseMeta.textContent = `${log.status} · ${log.duration}ms`;
-				elements.requestUrl.textContent = log.url;
+				const endpoint = state.endpoints.find(candidate => candidate.name === log.endpointName);
+				if (!endpoint) return;
+
+				state.activeEndpoint = endpoint;
+				renderEndpointList();
+				renderActiveEndpoint();
+				Object.entries(log.pathParams).forEach(([name, value]) => setInputValue('path', name, value));
+				Object.entries(log.queryParams).forEach(([name, value]) => setInputValue('query', name, value));
+				elements.bodyInput.value = log.body;
+				updateRequestUrl();
+				setResponse(log.responseMeta, log.responseText, log.status === 'ERR' || (typeof log.status === 'number' && log.status >= 400) ? 'error' : 'success');
 			});
 			elements.requestLogs.append(item);
 		});
@@ -467,11 +545,21 @@ export const initExplorerApp = (options: ExplorerAppOptions = {}): void => {
 		url,
 		status,
 		duration,
+		pathParams,
+		queryParams,
+		body,
+		responseMeta,
+		responseText,
 	}: {
 		endpoint: ApiMetadataItem;
 		url: string;
 		status: number | 'ERR';
 		duration: number;
+		pathParams: Record<string, string>;
+		queryParams: Record<string, string>;
+		body: string;
+		responseMeta: string;
+		responseText: string;
 	}): void => {
 		state.logs.unshift({
 			id: Date.now(),
@@ -480,6 +568,11 @@ export const initExplorerApp = (options: ExplorerAppOptions = {}): void => {
 			url,
 			status,
 			duration,
+			pathParams,
+			queryParams,
+			body,
+			responseMeta,
+			responseText,
 		});
 		state.logs = state.logs.slice(0, 30);
 		renderLogs();
@@ -492,6 +585,8 @@ export const initExplorerApp = (options: ExplorerAppOptions = {}): void => {
 
 		const url = buildUrl();
 		const init: RequestInit = { method: endpoint.method };
+		const requestParams = captureParamValues(endpoint);
+		const requestBody = elements.bodyInput.value;
 
 		if (endpoint.method !== 'GET') {
 			const rawBody = elements.bodyInput.value.trim();
@@ -500,32 +595,58 @@ export const initExplorerApp = (options: ExplorerAppOptions = {}): void => {
 					init.body = JSON.stringify(JSON.parse(rawBody)) as BodyInit;
 					init.headers = { 'Content-Type': 'application/json' };
 				} catch (error) {
-					elements.responseMeta.textContent = 'JSON 格式错误';
-					elements.responseOutput.textContent = error instanceof Error ? error.message : String(error);
+					const responseMeta = 'JSON 格式错误';
+					const responseText = error instanceof Error ? error.message : String(error);
+					setResponse(responseMeta, responseText, 'error');
 					return;
 				}
 			}
 		}
 
 		elements.sendButton.disabled = true;
-		elements.responseMeta.textContent = '请求中...';
+		setResponse('请求中...', '正在等待服务响应...', 'loading');
 		const startedAt = performance.now();
 
 		try {
 			const response = await fetch(url, init);
 			const duration = Math.round(performance.now() - startedAt);
 			const contentType = response.headers.get('content-type') || '';
-			const body = (
-				contentType.includes('application/json') ? await response.json() : await response.text()
-			) as ResponseBody;
-			elements.responseMeta.textContent = `${response.status} ${response.statusText} · ${duration}ms`;
-			elements.responseOutput.textContent = typeof body === 'string' ? body : formatJson(body);
-			addLog({ endpoint, url, status: response.status, duration });
+			const rawBody = await response.text();
+			let responseText = rawBody;
+			if (contentType.includes('application/json') && rawBody) {
+				try {
+					responseText = formatJson(JSON.parse(rawBody));
+				} catch {
+					responseText = rawBody;
+				}
+			}
+			const responseMeta = `${response.status} ${response.statusText} · ${duration}ms`;
+			setResponse(responseMeta, responseText, response.ok ? 'success' : 'error');
+			addLog({
+				endpoint,
+				url,
+				status: response.status,
+				duration,
+				...requestParams,
+				body: requestBody,
+				responseMeta,
+				responseText,
+			});
 		} catch (error) {
 			const duration = Math.round(performance.now() - startedAt);
-			elements.responseMeta.textContent = `请求失败 · ${duration}ms`;
-			elements.responseOutput.textContent = error instanceof Error ? error.message : String(error);
-			addLog({ endpoint, url, status: 'ERR', duration });
+			const responseMeta = `请求失败 · ${duration}ms`;
+			const responseText = error instanceof Error ? error.message : String(error);
+			setResponse(responseMeta, responseText, 'error');
+			addLog({
+				endpoint,
+				url,
+				status: 'ERR',
+				duration,
+				...requestParams,
+				body: requestBody,
+				responseMeta,
+				responseText,
+			});
 		} finally {
 			elements.sendButton.disabled = false;
 		}
@@ -533,6 +654,7 @@ export const initExplorerApp = (options: ExplorerAppOptions = {}): void => {
 
 	const resetActiveEndpoint = (): void => {
 		renderActiveEndpoint();
+		clearResponse();
 	};
 
 	const loadMetadata = async (): Promise<void> => {
@@ -558,7 +680,19 @@ export const initExplorerApp = (options: ExplorerAppOptions = {}): void => {
 	elements.requestForm.addEventListener('submit', event => {
 		void submitRequest(event as SubmitEvent);
 	});
+	elements.requestForm.addEventListener('keydown', event => {
+		if ((event.ctrlKey || event.metaKey) && event.key === 'Enter' && !elements.sendButton.disabled) {
+			event.preventDefault();
+			void submitRequest(new SubmitEvent('submit', { bubbles: true, cancelable: true }));
+		}
+	});
 	elements.resetButton.addEventListener('click', resetActiveEndpoint);
+	elements.copyUrlButton.addEventListener('click', () => {
+		void withCopyFeedback(elements.copyUrlButton, buildUrl());
+	});
+	elements.copyResponseButton.addEventListener('click', () => {
+		void withCopyFeedback(elements.copyResponseButton, elements.responseOutput.textContent || '');
+	});
 	elements.clearLogsButton.addEventListener('click', () => {
 		state.logs = [];
 		renderLogs();
@@ -566,8 +700,7 @@ export const initExplorerApp = (options: ExplorerAppOptions = {}): void => {
 
 	loadMetadata().catch(error => {
 		elements.endpointCount.textContent = '接口加载失败';
-		elements.responseMeta.textContent = '加载失败';
-		elements.responseOutput.textContent = error instanceof Error ? error.message : String(error);
+		setResponse('加载失败', error instanceof Error ? error.message : String(error), 'error');
 	});
 };
 

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
       "handle": "filesystem"
     },
     {
+      "src": "/favicon.ico",
+      "dest": "/docs-dist/logo.svg"
+    },
+    {
       "src": "/",
       "dest": "/docs-dist/index.html"
     },

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "functions": {
     "api/index.ts": {
       "maxDuration": 30,
-      "includeFiles": "src/**,dist/**,public/**,config/**"
+      "includeFiles": "src/**,config/**"
     }
   },
   "routes": [

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,8 @@
   "buildCommand": "npm run vercel-build",
   "functions": {
     "api/index.ts": {
-      "maxDuration": 30
+      "maxDuration": 30,
+      "includeFiles": "src/**,dist/**,public/**,config/**"
     }
   },
   "routes": [

--- a/vercel.json
+++ b/vercel.json
@@ -1,38 +1,35 @@
 {
   "buildCommand": "npm run vercel-build",
+  "outputDirectory": "docs-dist",
   "functions": {
     "api/index.ts": {
       "maxDuration": 30,
-      "includeFiles": "{src,config}/**"
+      "includeFiles": "{src,config,public}/**"
     }
   },
   "routes": [
     {
-      "handle": "filesystem"
-    },
-    {
       "src": "/favicon.ico",
-      "dest": "/docs-dist/logo.svg"
+      "dest": "/logo.svg"
     },
     {
       "src": "/",
-      "dest": "/docs-dist/index.html"
+      "dest": "/index.html"
     },
     {
-      "src": "/(guide|api|reference)",
-      "dest": "/docs-dist/$1/index.html"
+      "src": "/(guide|api|reference)/?",
+      "dest": "/$1/index.html"
+    },
+    {
+      "src": "/(guide|api|reference)/(.*\\.html)",
+      "dest": "/$1/$2"
     },
     {
       "src": "/(guide|api|reference)/(.*)",
-      "dest": "/docs-dist/$1/$2"
+      "dest": "/$1/$2.html"
     },
     {
-      "src": "/assets/(.*)",
-      "dest": "/docs-dist/assets/$1"
-    },
-    {
-      "src": "\\.(html|css|js|png|jpg|svg|woff2|json)$",
-      "dest": "/docs-dist$&"
+      "handle": "filesystem"
     },
     {
       "src": "/(.*)",

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "functions": {
     "api/index.ts": {
       "maxDuration": 30,
-      "includeFiles": ["src/**", "config/**"]
+      "includeFiles": "{src,config}/**"
     }
   },
   "routes": [

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "functions": {
     "api/index.ts": {
       "maxDuration": 30,
-      "includeFiles": "src/**,config/**"
+      "includeFiles": ["src/**", "config/**"]
     }
   },
   "routes": [


### PR DESCRIPTION
## 背景

参考 [xiaomingky/qq-music-api](https://github.com/xiaomingky/qq-music-api) 的改动，使本项目可直接部署到 Vercel。

## 改动内容（仅 `vercel.json`）

为 `api/index.ts` 函数新增 `includeFiles`，确保 Serverless Function 部署时把运行时所需目录一起打包：

```diff
 "functions": {
   "api/index.ts": {
-    "maxDuration": 30
+    "maxDuration": 30,
+    "includeFiles": "src/**,dist/**,public/**,config/**"
   }
 }
```

> 相比 xiaomingky 的版本，把缩进修正为与文件其余部分一致的 2 空格（原版用了 tab）。

## 不采纳的改动：移除 `workspaces`

xiaomingky fork 还移除了 `package.json` 里的 `workspaces` 字段，本 PR **不采纳** 这一改动，原因如下：

- CI 发布流程 [.github/workflows/package.yml](https://github.com/sansenjian/qq-music-api/blob/dev/.github/workflows/package.yml) 多处依赖 `npm --workspace @sansenjian/qq-music-api-mcp ...`：
  - 第 94 行同步 MCP 版本号（beta 通道）
  - 第 207 行发布 MCP 到 NPM
  - 第 227 行发布 MCP 到 GitHub Packages
  - 移除后这些命令会报 “No workspace” 并失败，**双包发布全部中断**。
- 本地脚本 `build:mcp` / `mcp` / `mcp:dev` 也用 `--workspace`，移除后失效；其中 `build:mcp` 是 `npm run build` 的一部分，会导致 `npm run build`、`npm test` 等连锁失败。
- MCP 子包 [packages/mcp/src/root-compat.ts](https://github.com/sansenjian/qq-music-api/blob/dev/packages/mcp/src/root-compat.ts) 通过相对路径 `../../../src/...` 引用根包源码，构建时需要 `src/` 存在 —— 这正是本 PR `includeFiles` 想解决的问题，无需靠移除 workspaces 来实现。

## 影响范围

- ✅ Vercel 部署：Serverless Function 能正确拿到 `src/`、`dist/`、`public/`、`config/`，解决 MCP/根包源码缺失问题。
- ✅ npm 发布、本地构建、MCP 工作区：不受影响，`workspaces` 保留。

## 来源

参考 xiaomingky fork 的 `9b918d7`（vercel.json）提交；`a903aa3`（移除 workspaces）经评估不采纳。